### PR TITLE
Fix #8, Resolve UT uninit var static analysis warnings

### DIFF
--- a/unit-test/md_cmds_tests.c
+++ b/unit-test/md_cmds_tests.c
@@ -662,7 +662,7 @@ void MD_ProcessJamCmd_Test_CantResolveJamAddr(void)
     UT_CmdBuf.CmdJam.EntryId     = 2;
     UT_CmdBuf.CmdJam.FieldLength = 1;
 
-    strncpy(UT_CmdBuf.CmdJam.DwellAddress.SymName, "address", 10);
+    strncpy(UT_CmdBuf.CmdJam.DwellAddress.SymName, "address", sizeof(UT_CmdBuf.CmdJam.DwellAddress.SymName) - 1);
 
     /* Set to satisfy condition "MD_ResolveSymAddr(&Jam->DwellAddress,&ResolvedAddr) == FALSE" */
     UT_SetDeferredRetcode(UT_KEY(MD_ResolveSymAddr), 1, false);
@@ -1199,7 +1199,7 @@ void MD_ProcessSignatureCmd_Test_InvalidSignatureLength(void)
     TestMsgId = CFE_SB_ValueToMsgId(MD_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
-    for (i = 0; i < MD_SIGNATURE_FIELD_LENGTH; i++)
+    for (i = 0; i < sizeof(UT_CmdBuf.CmdSetSignature.Signature); i++)
     {
         UT_CmdBuf.CmdSetSignature.Signature[i] = 'x';
     }
@@ -1275,7 +1275,7 @@ void MD_ProcessSignatureCmd_Test_Success(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     UT_CmdBuf.CmdSetSignature.TableId = 1;
-    strncpy(UT_CmdBuf.CmdSetSignature.Signature, "signature", MD_SIGNATURE_FIELD_LENGTH);
+    strncpy(UT_CmdBuf.CmdSetSignature.Signature, "signature", sizeof(UT_CmdBuf.CmdSetSignature.Signature) - 1);
 
     /* Prevents segmentation fault in call to subfunction MD_UpdateTableSignature */
     UT_SetHookFunction(UT_KEY(CFE_TBL_GetAddress), &MD_CMDS_TEST_CFE_TBL_GetAddressHook, NULL);
@@ -1320,7 +1320,7 @@ void MD_ProcessSignatureCmd_Test_NoUpdateTableSignature(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
 
     UT_CmdBuf.CmdSetSignature.TableId = 1;
-    strncpy(UT_CmdBuf.CmdSetSignature.Signature, "signature", MD_SIGNATURE_FIELD_LENGTH);
+    strncpy(UT_CmdBuf.CmdSetSignature.Signature, "signature", sizeof(UT_CmdBuf.CmdSetSignature.Signature) - 1);
 
     /* Prevents segmentation fault in call to subfunction MD_UpdateTableSignature */
     UT_SetHookFunction(UT_KEY(CFE_TBL_GetAddress), &MD_CMDS_TEST_CFE_TBL_GetAddressHook, NULL);

--- a/unit-test/md_utils_tests.c
+++ b/unit-test/md_utils_tests.c
@@ -465,7 +465,7 @@ void MD_Verify16Aligned_Test(void)
 void MD_ResolveSymAddr_Test(void)
 {
     MD_SymAddr_t SymAddr;
-    cpuaddr      ResolvedAddr;
+    cpuaddr      ResolvedAddr = 0;
     bool         Result;
 
     memset(&SymAddr, 0, sizeof(MD_SymAddr_t));

--- a/unit-test/utilities/md_test_utils.c
+++ b/unit-test/utilities/md_test_utils.c
@@ -70,7 +70,7 @@ void UT_Handler_CFE_EVS_SendEvent(void *UserObj, UT_EntryKey_t FuncKey, const UT
 void UT_Handler_CFE_ES_WriteToSysLog(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context, va_list va)
 {
     strncpy(context_CFE_ES_WriteToSysLog.Spec, UT_Hook_GetArgValueByName(Context, "SpecStringPtr", const char *),
-            CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+            CFE_MISSION_EVS_MAX_MESSAGE_LENGTH - 1);
     context_CFE_ES_WriteToSysLog.Spec[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH - 1] = '\0';
 }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #8

**Testing performed**
CI + static analysis run

**Expected behavior changes**
None, just squashes static analysis warnings

**System(s) tested on**
 - Hardware: VM
 - OS: Ubuntu 18.04
 - Versions: Bundle main + apps + related static analysis resolution branches

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC