### PR TITLE
Fix #34, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/src/md_app.c
+++ b/fsw/src/md_app.c
@@ -78,7 +78,6 @@ void MD_AppMain(void)
         /* Copy any newly loaded tables */
         for (TblIndex = 0; TblIndex < MD_NUM_DWELL_TABLES; TblIndex++)
         {
-
             MD_ManageDwellTable(TblIndex);
 
         } /* end for each table loop */
@@ -107,7 +106,6 @@ void MD_AppMain(void)
         /* Process Executive Request */
         if ((Status == CFE_SUCCESS) && (BufPtr != NULL))
         {
-
             CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
 
             switch (CFE_SB_MsgIdToValue(MessageID))
@@ -166,8 +164,7 @@ void MD_AppMain(void)
     ** Exit the Application
     */
     CFE_ES_ExitApp(MD_AppData.RunStatus);
-
-} /* End of MD_AppMain */
+}
 
 /******************************************************************************/
 
@@ -190,7 +187,7 @@ int32 MD_AppInit(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("MD_APP:Call to CFE_EVS_Register Failed:RC=%d\n", Status);
-    } /* end if */
+    }
 
     /*
     ** Set up for Software Bus Services
@@ -206,8 +203,7 @@ int32 MD_AppInit(void)
     if (Status == CFE_SUCCESS)
     {
         Status = MD_InitTableServices();
-
-    } /* end if */
+    }
 
     /*
     ** Issue Event Message
@@ -217,12 +213,10 @@ int32 MD_AppInit(void)
         Status =
             CFE_EVS_SendEvent(MD_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "MD Initialized.  Version %d.%d.%d.%d",
                               MD_MAJOR_VERSION, MD_MINOR_VERSION, MD_REVISION, MD_MISSION_REV);
-
-    } /* end if */
+    }
 
     return Status;
-
-} /* End of MD_AppInit */
+}
 
 /******************************************************************************/
 void MD_InitControlStructures(void)
@@ -246,6 +240,7 @@ void MD_InitControlStructures(void)
 
     } /* end for TblIndex loop */
 }
+
 /******************************************************************************/
 int32 MD_InitSoftwareBusServices(void)
 {
@@ -278,59 +273,52 @@ int32 MD_InitSoftwareBusServices(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(MD_CREATE_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "Failed to create pipe.  RC = %d", Status);
-    } /* end if */
+    }
 
     /*
     ** Subscribe to Housekeeping request commands
     */
     if (Status == CFE_SUCCESS)
     {
-
         Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(MD_SEND_HK_MID), MD_AppData.CmdPipe);
 
         if (Status != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(MD_SUB_HK_ERR_EID, CFE_EVS_EventType_ERROR, "Failed to subscribe to HK requests  RC = %d",
                               Status);
-        } /* end if */
-
-    } /* end if */
+        }
+    }
 
     /*
     ** Subscribe to MD ground command packets
     */
     if (Status == CFE_SUCCESS)
     {
-
         Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(MD_CMD_MID), MD_AppData.CmdPipe);
 
         if (Status != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(MD_SUB_CMD_ERR_EID, CFE_EVS_EventType_ERROR, "Failed to subscribe to commands.  RC = %d",
                               Status);
-        } /* end if */
-
-    } /* end if */
+        }
+    }
 
     /*
     ** Subscribe to MD wakeup packets
     */
     if (Status == CFE_SUCCESS)
     {
-
         Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(MD_WAKEUP_MID), MD_AppData.CmdPipe);
 
         if (Status != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(MD_SUB_WAKEUP_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Failed to subscribe to wakeup messages.  RC = %d", Status);
-        } /* end if */
-
-    } /* end if */
+        }
+    }
 
     return Status;
-
-} /* End of MD_InitSoftwareBusServices */
+}
 
 /******************************************************************************/
 
@@ -446,14 +434,14 @@ int32 MD_InitTableServices(void)
                               "Dwell Table(s) are too large to register: %u bytes, %d entries",
                               (unsigned int)MD_TBL_LOAD_LNGTH, MD_DWELL_TABLE_SIZE);
             TableInitValidFlag = false;
-        } /* end if */
+        }
 
         else if (Status != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(MD_TBL_REGISTER_CRIT_EID, CFE_EVS_EventType_CRITICAL,
                               "CFE_TBL_Register error %d received for tbl#%d", Status, TblIndex + 1);
             TableInitValidFlag = false;
-        } /* end if */
+        }
         else
         {
             /* Table is registered and valid */
@@ -476,7 +464,7 @@ int32 MD_InitTableServices(void)
                 CFE_ES_WriteToSysLog("MD_APP: Error 0x%08X received loading tbl#%d\n", (unsigned int)Status,
                                      TblIndex + 1);
                 TableInitValidFlag = false;
-            } /* end if */
+            }
             else
             {
                 TblInits++;
@@ -503,8 +491,7 @@ int32 MD_InitTableServices(void)
     {
         return Status;
     }
-
-} /* End of MD_InitTableServices */
+}
 
 /******************************************************************************/
 int32 MD_ManageDwellTable(uint8 TblIndex)
@@ -578,8 +565,7 @@ int32 MD_ManageDwellTable(uint8 TblIndex)
     }
 
     return Status;
-
-} /* End of MD_ManageDwellTable */
+}
 
 /******************************************************************************/
 
@@ -623,7 +609,6 @@ void MD_ExecRequest(const CFE_SB_Buffer_t *BufPtr)
     }
     else
     {
-
         /* Process command */
         switch (CommandCode)
         {
@@ -665,8 +650,7 @@ void MD_ExecRequest(const CFE_SB_Buffer_t *BufPtr)
 #endif
         } /* End Switch */
     }
-
-} /* End of MD_ExecRequest */
+}
 
 /******************************************************************************/
 void MD_HkStatus()
@@ -718,7 +702,7 @@ void MD_HkStatus()
     */
     CFE_SB_TimeStampMsg(&HkPktPtr->TlmHeader.Msg);
     CFE_SB_TransmitMsg(&HkPktPtr->TlmHeader.Msg, true);
-} /* End of MD_HkStatus */
+}
 
 /******************************************************************************/
 
@@ -737,8 +721,4 @@ int16 MD_SearchCmdHndlrTbl(CFE_MSG_FcnCode_t CommandCode)
     }
 
     return TblIndx;
-} /* End of MD_SearchCmdHndlrTbl() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/md_app.h
+++ b/fsw/src/md_app.h
@@ -105,7 +105,6 @@ typedef struct
 #if MD_SIGNATURE_OPTION == 1
     char Signature[MD_SIGNATURE_FIELD_LENGTH]; /**< \brief Signature string used for dwell table to dwell pkt */
 #endif
-
 } MD_DwellPacketControl_t;
 
 /**

--- a/fsw/src/md_cmds.c
+++ b/fsw/src/md_cmds.c
@@ -124,7 +124,7 @@ void MD_ProcessStartCmd(const CFE_SB_Buffer_t *BufPtr)
                           "%s command rejected because no tables were specified in table mask (0x%04X)", "Start Dwell",
                           Start->TableMask);
     }
-} /* End of MD_ProcessStartCmd */
+}
 
 /******************************************************************************/
 
@@ -185,7 +185,7 @@ void MD_ProcessStopCmd(const CFE_SB_Buffer_t *BufPtr)
                           Stop->TableMask);
         MD_AppData.ErrCounter++;
     }
-} /* End of MD_ProcessStopCmd */
+}
 
 /******************************************************************************/
 
@@ -400,7 +400,7 @@ void MD_ProcessJamCmd(const CFE_SB_Buffer_t *BufPtr)
     {
         MD_AppData.ErrCounter++;
     }
-} /* End of MD_ProcessJamCmd */
+}
 
 /******************************************************************************/
 #if MD_SIGNATURE_OPTION == 1
@@ -473,7 +473,3 @@ void MD_ProcessSignatureCmd(const CFE_SB_Buffer_t *BufPtr)
 }
 
 #endif
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/src/md_dwell_pkt.c
+++ b/fsw/src/md_dwell_pkt.c
@@ -46,14 +46,12 @@ void MD_DwellLoop(void)
     /* Check each dwell table */
     for (TblIndex = 0; TblIndex < MD_NUM_DWELL_TABLES; TblIndex++)
     {
-
         TblPtr            = &MD_AppData.MD_DwellTables[TblIndex];
         NumDwellAddresses = TblPtr->AddrCount;
 
         /* Process enabled dwell tables */
         if ((TblPtr->Enabled == MD_DWELL_STREAM_ENABLED) && (TblPtr->Rate > 0))
         {
-
             /*
             ** Handle special case that dwell pkt is already full because
             ** pkt size was shortened after data had been written to the pkt.
@@ -61,7 +59,6 @@ void MD_DwellLoop(void)
 
             if (TblPtr->CurrentEntry >= NumDwellAddresses)
             {
-
                 MD_SendDwellPkt(TblIndex);
 
                 /* Initialize CurrentEntry index */
@@ -99,7 +96,6 @@ void MD_DwellLoop(void)
 
                     /* Case:  Just filled last active entry of dwell table */
                     {
-
                         /*
                         ** Send dwell packet
                         */
@@ -141,8 +137,7 @@ void MD_DwellLoop(void)
         } /* end if current dwell stream enabled */
 
     } /* end for each dwell table */
-
-} /* End of MD_DwellLoop */
+}
 
 /******************************************************************************/
 
@@ -199,8 +194,7 @@ int32 MD_GetDwellData(uint16 TblIndex, uint16 EntryIndex)
     TblPtr->PktOffset += NumBytes;
 
     return Status;
-
-} /* End of MD_GetDwellData */
+}
 
 /******************************************************************************/
 
@@ -238,8 +232,7 @@ void MD_SendDwellPkt(uint16 TableIndex)
     */
     CFE_SB_TimeStampMsg(&PktPtr->TlmHeader.Msg);
     CFE_SB_TransmitMsg(&PktPtr->TlmHeader.Msg, true);
-
-} /* End of MD_SendDwellPkt */
+}
 
 /******************************************************************************/
 
@@ -248,9 +241,4 @@ void MD_StartDwellStream(uint16 TableIndex)
     MD_AppData.MD_DwellTables[TableIndex].Countdown    = 1;
     MD_AppData.MD_DwellTables[TableIndex].CurrentEntry = 0;
     MD_AppData.MD_DwellTables[TableIndex].PktOffset    = 0;
-
-} /* End of MD_StartDwellStream */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/md_dwell_tbl.c
+++ b/fsw/src/md_dwell_tbl.c
@@ -146,8 +146,7 @@ int32 MD_TableValidationFunc(void *TblPtr)
     } /* end else MD_ReadDwellTable */
 
     return Status;
-
-} /* End of MD_TableValidationFunc */
+}
 
 /******************************************************************************/
 int32 MD_ReadDwellTable(const MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCountPtr, uint16 *SizePtr, uint32 *RatePtr)
@@ -168,7 +167,7 @@ int32 MD_ReadDwellTable(const MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCou
     } /* end while */
 
     return CFE_SUCCESS;
-} /* End of MD_ReadDwellTable */
+}
 /******************************************************************************/
 int32 MD_CheckTableEntries(MD_DwellTableLoad_t *TblPtr, uint16 *ErrorEntryArg)
 {
@@ -190,7 +189,6 @@ int32 MD_CheckTableEntries(MD_DwellTableLoad_t *TblPtr, uint16 *ErrorEntryArg)
     */
     for (EntryIndex = 0; EntryIndex < MD_DWELL_TABLE_SIZE; EntryIndex++)
     {
-
         Status = MD_ValidTableEntry(&TblPtr->Entry[EntryIndex]);
 
         if (Status == CFE_SUCCESS)
@@ -235,8 +233,7 @@ int32 MD_CheckTableEntries(MD_DwellTableLoad_t *TblPtr, uint16 *ErrorEntryArg)
                       (int)UnusedCount);
 
     return FirstErrorCode;
-
-} /* End of MD_CheckTableEntries */
+}
 
 /******************************************************************************/
 int32 MD_ValidTableEntry(MD_TableLoadEntry_t *TblEntryPtr)
@@ -256,7 +253,7 @@ int32 MD_ValidTableEntry(MD_TableLoadEntry_t *TblEntryPtr)
         if (MD_ResolveSymAddr(&TblEntryPtr->DwellAddress, &ResolvedAddr) != true)
         { /* Symbol was non-null AND was not in Symbol Table */
             Status = MD_RESOLVE_ERROR;
-        } /* end MD_ResolveSymAddr */
+        }
 
         else if (MD_ValidAddrRange(ResolvedAddr, (uint32)DwellLength) != true)
         { /* Address is in invalid range  */
@@ -289,8 +286,7 @@ int32 MD_ValidTableEntry(MD_TableLoadEntry_t *TblEntryPtr)
     } /* end else */
 
     return Status;
-
-} /* End of MD_ValidTableEntry */
+}
 
 /******************************************************************************/
 void MD_CopyUpdatedTbl(MD_DwellTableLoad_t *MD_LoadTablePtr, uint8 TblIndex)
@@ -332,7 +328,7 @@ void MD_CopyUpdatedTbl(MD_DwellTableLoad_t *MD_LoadTablePtr, uint8 TblIndex)
 
     /* Update Dwell Table Control Info, used to process dwell packets */
     MD_UpdateDwellControlInfo((uint16)TblIndex);
-} /* End of MD_CopyUpdatedTbl */
+}
 
 /******************************************************************************/
 int32 MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
@@ -362,7 +358,7 @@ int32 MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
     }
 
     return Status;
-} /* End of MD_UpdateTableEnabledField */
+}
 
 /******************************************************************************/
 
@@ -410,7 +406,7 @@ int32 MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewL
     }
 
     return Status;
-} /* End of MD_UpdateTableDwellEntry */
+}
 
 /******************************************************************************/
 #if MD_SIGNATURE_OPTION == 1
@@ -451,6 +447,3 @@ int32 MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIGNATURE_
 }
 
 #endif
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/src/md_msg.h
+++ b/fsw/src/md_msg.h
@@ -61,7 +61,6 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< Command Header */
-
 } MD_NoArgsCmd_t;
 
 /**

--- a/fsw/src/md_utils.c
+++ b/fsw/src/md_utils.c
@@ -50,8 +50,7 @@ bool MD_TableIsInMask(int16 TableId, uint16 TableMask)
         Status = true;
 
     return Status;
-
-} /* End MD_TableIsInMask */
+}
 
 /******************************************************************************/
 
@@ -79,7 +78,7 @@ void MD_UpdateDwellControlInfo(uint16 TableIndex)
     TblPtr->AddrCount = NumDwellAddresses;
     TblPtr->DataSize  = NumDwellDataBytes;
     TblPtr->Rate      = NumDwellDelayCounts;
-} /* MD_UpdateDwellControlInfo */
+}
 
 /******************************************************************************/
 
@@ -113,6 +112,7 @@ bool MD_ValidAddrRange(cpuaddr Addr, uint32 Size)
 
     return IsValid;
 }
+
 /******************************************************************************/
 bool MD_ValidTableId(uint16 TableId)
 {
@@ -130,7 +130,6 @@ bool MD_ValidTableId(uint16 TableId)
 
 bool MD_ValidFieldLength(uint16 FieldLength)
 {
-
     bool IsValid = false;
 
     if ((FieldLength == 0) || (FieldLength == 1) || (FieldLength == 2) || (FieldLength == 4))
@@ -224,7 +223,3 @@ bool MD_ResolveSymAddr(MD_SymAddr_t *SymAddr, cpuaddr *ResolvedAddr)
     }
     return Valid;
 }
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/md_dw01.c
+++ b/fsw/tables/md_dw01.c
@@ -67,7 +67,3 @@ MD_DwellTableLoad_t MD_Default_Dwell1_Tbl = {
     }};
 
 CFE_TBL_FILEDEF(MD_Default_Dwell1_Tbl, MD.DWELL_TABLE1, MD Dwell Table 1, md_dw01.tbl)
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/md_dw02.c
+++ b/fsw/tables/md_dw02.c
@@ -67,7 +67,3 @@ MD_DwellTableLoad_t MD_Default_Dwell2_Tbl = {
     }};
 
 CFE_TBL_FILEDEF(MD_Default_Dwell2_Tbl, MD.DWELL_TABLE2, MD Dwell Table 2, md_dw02.tbl)
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/md_dw03.c
+++ b/fsw/tables/md_dw03.c
@@ -67,7 +67,3 @@ MD_DwellTableLoad_t MD_Default_Dwell3_Tbl = {
     }};
 
 CFE_TBL_FILEDEF(MD_Default_Dwell3_Tbl, MD.DWELL_TABLE3, MD Dwell Table 3, md_dw03.tbl)
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/md_dw04.c
+++ b/fsw/tables/md_dw04.c
@@ -67,7 +67,3 @@ MD_DwellTableLoad_t MD_Default_Dwell4_Tbl = {
     }};
 
 CFE_TBL_FILEDEF(MD_Default_Dwell4_Tbl, MD.DWELL_TABLE4, MD Dwell Table 4, md_dw04.tbl)
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/md_app_tests.c
+++ b/unit-test/md_app_tests.c
@@ -77,8 +77,7 @@ void MD_AppMain_Test_AppInitError(void)
 
     /* Generates 1 log message we don't care about in this test */
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
-} /* end MD_AppMain_Test_AppInitError */
+}
 
 void MD_AppMain_Test_RcvMsgError(void)
 {
@@ -116,8 +115,7 @@ void MD_AppMain_Test_RcvMsgError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppMain_Test_RcvMsgError */
+}
 
 void MD_AppMain_Test_RcvMsgTimeout(void)
 {
@@ -141,8 +139,7 @@ void MD_AppMain_Test_RcvMsgTimeout(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppMain_Test_RcvMsgTimeout */
+}
 
 void MD_AppMain_Test_RcvMsgNullBuffer(void)
 {
@@ -164,8 +161,7 @@ void MD_AppMain_Test_RcvMsgNullBuffer(void)
     /* Generates 2 event messages we don't care about in this test */
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppMain_Test_RcvMsgNullBuffer */
+}
 
 void MD_AppMain_Test_WakeupNominal(void)
 {
@@ -205,8 +201,7 @@ void MD_AppMain_Test_WakeupNominal(void)
 
     uint8 call_count_MD_DwellLoop = UT_GetStubCount(UT_KEY(MD_DwellLoop));
     UtAssert_INT32_EQ(call_count_MD_DwellLoop, 1);
-
-} /* end MD_AppMain_Test_WakeupNominal */
+}
 
 void MD_AppMain_Test_WakeupLengthError(void)
 {
@@ -253,8 +248,7 @@ void MD_AppMain_Test_WakeupLengthError(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[2].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[2].Spec);
-
-} /* end MD_AppMain_Test_WakeupLengthError */
+}
 
 void MD_AppMain_Test_CmdNominal(void)
 {
@@ -292,8 +286,7 @@ void MD_AppMain_Test_CmdNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppMain_Test_CmdNominal */
+}
 
 void MD_AppMain_Test_SendHkNominal(void)
 {
@@ -327,8 +320,7 @@ void MD_AppMain_Test_SendHkNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppMain_Test_SendHkNominal */
+}
 
 void MD_AppMain_Test_SendHkLengthError(void)
 {
@@ -374,8 +366,7 @@ void MD_AppMain_Test_SendHkLengthError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppMain_Test_SendHkLengthError */
+}
 
 void MD_AppMain_Test_InvalidMessageID(void)
 {
@@ -416,8 +407,7 @@ void MD_AppMain_Test_InvalidMessageID(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppMain_Test_InvalidMessageID */
+}
 
 void MD_AppInit_Test_Nominal(void)
 {
@@ -451,8 +441,7 @@ void MD_AppInit_Test_Nominal(void)
 
     UtAssert_INT32_EQ(MD_AppData.CmdCounter, 0);
     UtAssert_INT32_EQ(MD_AppData.ErrCounter, 0);
-
-} /* end MD_AppInit_Test_Nominal */
+}
 
 void MD_AppInit_Test_EvsRegisterNotSuccess(void)
 {
@@ -484,8 +473,7 @@ void MD_AppInit_Test_EvsRegisterNotSuccess(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppInit_Test_EvsRegisterNotSuccess */
+}
 
 void MD_AppInit_Test_InitSoftwareBusServicesNotSuccess(void)
 {
@@ -506,8 +494,7 @@ void MD_AppInit_Test_InitSoftwareBusServicesNotSuccess(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 system log message we don't care about in this test */
-
-} /* end MD_AppInit_Test_InitSoftwareBusServicesNotSuccess */
+}
 
 void MD_AppInit_Test_InitTableServicesNotSuccess(void)
 {
@@ -527,8 +514,7 @@ void MD_AppInit_Test_InitTableServicesNotSuccess(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_AppInit_Test_InitTableServicesNotSuccess */
+}
 
 void MD_InitControlStructures_Test(void)
 {
@@ -617,8 +603,7 @@ void MD_InitControlStructures_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitControlStructures_Test */
+}
 
 void MD_InitSoftwareBusServices_Test_Nominal(void)
 {
@@ -642,8 +627,7 @@ void MD_InitSoftwareBusServices_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitSoftwareBusServices_Test_Nominal */
+}
 
 void MD_InitSoftwareBusServices_Test_CreatePipeError(void)
 {
@@ -681,8 +665,7 @@ void MD_InitSoftwareBusServices_Test_CreatePipeError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitSoftwareBusServices_Test_CreatePipeError */
+}
 
 void MD_InitSoftwareBusServices_Test_SubscribeHkError(void)
 {
@@ -720,8 +703,7 @@ void MD_InitSoftwareBusServices_Test_SubscribeHkError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitSoftwareBusServices_Test_SubscribeHkError */
+}
 
 void MD_InitSoftwareBusServices_Test_SubscribeCmdError(void)
 {
@@ -759,8 +741,7 @@ void MD_InitSoftwareBusServices_Test_SubscribeCmdError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitSoftwareBusServices_Test_SubscribeCmdError */
+}
 
 void MD_InitSoftwareBusServices_Test_SubscribeWakeupError(void)
 {
@@ -799,8 +780,7 @@ void MD_InitSoftwareBusServices_Test_SubscribeWakeupError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitSoftwareBusServices_Test_SubscribeWakeupError */
+}
 
 void MD_InitTableServices_Test_GetAddressErrorAndLoadError(void)
 {
@@ -868,8 +848,7 @@ void MD_InitTableServices_Test_GetAddressErrorAndLoadError(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
-} /* end MD_InitTableServices_Test_GetAddressErrorAndLoadError */
+}
 
 void MD_InitTableServices_Test_TblRecoveredValidThenTblInits(void)
 {
@@ -914,8 +893,7 @@ void MD_InitTableServices_Test_TblRecoveredValidThenTblInits(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitTableServices_Test_TblRecoveredValidThenTblInits */
+}
 
 void MD_InitTableServices_Test_TblRecoveredNotValid(void)
 {
@@ -981,8 +959,7 @@ void MD_InitTableServices_Test_TblRecoveredNotValid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitTableServices_Test_TblRecoveredNotValid */
+}
 
 void MD_InitTableServices_Test_DwellStreamEnabled(void)
 {
@@ -1046,8 +1023,7 @@ void MD_InitTableServices_Test_DwellStreamEnabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitTableServices_Test_DwellStreamEnabled */
+}
 
 void MD_InitTableServices_Test_TblNotRecovered(void)
 {
@@ -1109,8 +1085,7 @@ void MD_InitTableServices_Test_TblNotRecovered(void)
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-} /* end MD_InitTableServices_Test_TblNotRecovered */
+}
 
 void MD_InitTableServices_Test_TblTooLarge(void)
 {
@@ -1156,8 +1131,7 @@ void MD_InitTableServices_Test_TblTooLarge(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitTableServices_Test_TblTooLarge */
+}
 
 void MD_InitTableServices_Test_TblRegisterCriticalError(void)
 {
@@ -1204,8 +1178,7 @@ void MD_InitTableServices_Test_TblRegisterCriticalError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_InitTableServices_Test_TblRegisterCriticalError */
+}
 
 void MD_InitTableServices_Test_TblNameError(void)
 {
@@ -1242,8 +1215,7 @@ void MD_InitTableServices_Test_TblNameError(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-
-} /* end MD_InitTableServices_Test_TblNameError */
+}
 
 void MD_InitTableServices_Test_TblFileNameError(void)
 {
@@ -1280,8 +1252,7 @@ void MD_InitTableServices_Test_TblFileNameError(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-
-} /* end MD_InitTableServices_Test_TblFileNameError */
+}
 
 void MD_ManageDwellTable_Test_ValidationPendingSucceedThenFail(void)
 {
@@ -1304,8 +1275,7 @@ void MD_ManageDwellTable_Test_ValidationPendingSucceedThenFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ManageDwellTable_Test_ValidationPendingSucceedThenFail */
+}
 
 void MD_ManageDwellTable_Test_UpdatePendingDwellStreamEnabled(void)
 {
@@ -1338,7 +1308,7 @@ void MD_ManageDwellTable_Test_UpdatePendingDwellStreamEnabled(void)
 
     uint8 call_count_MD_StartDwellStream = UT_GetStubCount(UT_KEY(MD_StartDwellStream));
     UtAssert_INT32_EQ(call_count_MD_StartDwellStream, 1);
-} /* end MD_ManageDwellTable_Test_UpdatePendingDwellStreamEnabled */
+}
 
 void MD_ManageDwellTable_Test_UpdatePendingDwellStreamDisabled(void)
 {
@@ -1373,8 +1343,7 @@ void MD_ManageDwellTable_Test_UpdatePendingDwellStreamDisabled(void)
 
     uint8 call_count_MD_StartDwellStream = UT_GetStubCount(UT_KEY(MD_StartDwellStream));
     UtAssert_INT32_EQ(call_count_MD_StartDwellStream, 0);
-
-} /* end MD_ManageDwellTable_Test_UpdatePendingDwellStreamDisabled */
+}
 
 void MD_ManageDwellTable_Test_TblNotUpdated(void)
 {
@@ -1402,8 +1371,7 @@ void MD_ManageDwellTable_Test_TblNotUpdated(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ManageDwellTable_Test_TblNotUpdated */
+}
 
 void MD_ManageDwellTable_Test_UpdatePendingTblCopyError(void)
 {
@@ -1438,8 +1406,7 @@ void MD_ManageDwellTable_Test_UpdatePendingTblCopyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ManageDwellTable_Test_UpdatePendingTblCopyError */
+}
 
 void MD_ManageDwellTable_Test_TblStatusErr(void)
 {
@@ -1471,8 +1438,7 @@ void MD_ManageDwellTable_Test_TblStatusErr(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ManageDwellTable_Test_TblStatusErr */
+}
 
 void MD_ManageDwellTable_Test_OtherStatus(void)
 {
@@ -1492,8 +1458,7 @@ void MD_ManageDwellTable_Test_OtherStatus(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ManageDwellTable_Test_OtherStatus */
+}
 
 void MD_ExecRequest_Test_SearchCmdHndlrTblError(void)
 {
@@ -1514,8 +1479,7 @@ void MD_ExecRequest_Test_SearchCmdHndlrTblError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MD_CC_NOT_IN_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end MD_ExecRequest_Test_SearchCmdHndlrTblError */
+}
 
 void MD_ExecRequest_Test_CmdLengthError(void)
 {
@@ -1553,8 +1517,7 @@ void MD_ExecRequest_Test_CmdLengthError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ExecRequest_Test_CmdLengthError */
+}
 
 void MD_ExecRequest_Test_Noop(void)
 {
@@ -1590,8 +1553,7 @@ void MD_ExecRequest_Test_Noop(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ExecRequest_Test_Noop */
+}
 
 void MD_ExecRequest_Test_ResetCounters(void)
 {
@@ -1628,8 +1590,7 @@ void MD_ExecRequest_Test_ResetCounters(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ExecRequest_Test_ResetCounters */
+}
 
 void MD_ExecRequest_Test_StartDwell(void)
 {
@@ -1652,8 +1613,7 @@ void MD_ExecRequest_Test_StartDwell(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ExecRequest_Test_StartDwell */
+}
 
 void MD_ExecRequest_Test_StopDwell(void)
 {
@@ -1676,8 +1636,7 @@ void MD_ExecRequest_Test_StopDwell(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ExecRequest_Test_StopDwell */
+}
 
 void MD_ExecRequest_Test_JamDwell(void)
 {
@@ -1700,8 +1659,7 @@ void MD_ExecRequest_Test_JamDwell(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ExecRequest_Test_JamDwell */
+}
 
 #if MD_SIGNATURE_OPTION == 1
 void MD_ExecRequest_Test_SetSignature(void)
@@ -1725,8 +1683,7 @@ void MD_ExecRequest_Test_SetSignature(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ExecRequest_Test_SetSignature */
+}
 #endif
 
 void MD_HkStatus_Test(void)
@@ -1803,8 +1760,7 @@ void MD_HkStatus_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_HkStatus_Test */
+}
 
 void UtTest_Setup(void)
 {
@@ -1889,9 +1845,4 @@ void UtTest_Setup(void)
 #endif
 
     UtTest_Add(MD_HkStatus_Test, MD_Test_Setup, MD_Test_TearDown, "MD_HkStatus_Test");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/md_cmds_tests.c
+++ b/unit-test/md_cmds_tests.c
@@ -61,7 +61,6 @@ int32 MD_CMDS_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint
 int32 MD_CMDS_TEST_MD_UpdateDwellControlInfoHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                                   const UT_StubContext_t *Context)
 {
-
     MD_AppData.MD_DwellTables[0].Enabled = MD_DWELL_STREAM_ENABLED;
 
     MD_AppData.MD_DwellTables[0].Rate = 0;
@@ -73,7 +72,6 @@ int32 MD_CMDS_TEST_MD_UpdateDwellControlInfoHook1(void *UserObj, int32 StubRetco
 int32 MD_CMDS_TEST_MD_UpdateDwellControlInfoHook2(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                                   const UT_StubContext_t *Context)
 {
-
     MD_AppData.MD_DwellTables[0].Enabled = MD_DWELL_STREAM_DISABLED;
 
     MD_AppData.MD_DwellTables[0].Rate = 1;
@@ -142,8 +140,7 @@ void MD_ProcessStartCmd_Test_ZeroRate(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessStartCmd_Test_ZeroRate */
+}
 
 void MD_ProcessStartCmd_Test_Success(void)
 {
@@ -193,8 +190,7 @@ void MD_ProcessStartCmd_Test_Success(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessStartCmd_Test_Success */
+}
 
 void MD_ProcessStartCmd_Test_EmptyTableMask(void)
 {
@@ -227,8 +223,7 @@ void MD_ProcessStartCmd_Test_EmptyTableMask(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessStartCmd_Test_EmptyTableMask */
+}
 
 void MD_ProcessStartCmd_Test_NoUpdateTableEnabledField(void)
 {
@@ -272,8 +267,7 @@ void MD_ProcessStartCmd_Test_NoUpdateTableEnabledField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessStartCmd_Test_NoUpdateTableEnabledField  */
+}
 
 void MD_ProcessStopCmd_Test_Success(void)
 {
@@ -321,8 +315,7 @@ void MD_ProcessStopCmd_Test_Success(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessStopCmd_Test_Success */
+}
 
 void MD_ProcessStopCmd_Test_EmptyTableMask(void)
 {
@@ -355,8 +348,7 @@ void MD_ProcessStopCmd_Test_EmptyTableMask(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessStopCmd_Test_EmptyTableMask */
+}
 
 void MD_ProcessStopCmd_Test_NoUpdateTableEnabledField(void)
 {
@@ -405,8 +397,7 @@ void MD_ProcessStopCmd_Test_NoUpdateTableEnabledField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessStopCmd_Test_NoUpdateTableEnabledField  */
+}
 
 void MD_ProcessJamCmd_Test_InvalidJamTable(void)
 {
@@ -440,8 +431,7 @@ void MD_ProcessJamCmd_Test_InvalidJamTable(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_InvalidJamTable */
+}
 
 void MD_ProcessJamCmd_Test_InvalidEntryArg(void)
 {
@@ -477,8 +467,7 @@ void MD_ProcessJamCmd_Test_InvalidEntryArg(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_InvalidEntryArg */
+}
 
 void MD_ProcessJamCmd_Test_SuccessNullZeroRate(void)
 {
@@ -544,8 +533,7 @@ void MD_ProcessJamCmd_Test_SuccessNullZeroRate(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_SuccessNullZeroRate */
+}
 
 void MD_ProcessJamCmd_Test_NullTableDwell(void)
 {
@@ -594,8 +582,7 @@ void MD_ProcessJamCmd_Test_NullTableDwell(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_NullTableDwell */
+}
 
 void MD_ProcessJamCmd_Test_NoUpdateTableDwell(void)
 {
@@ -643,8 +630,7 @@ void MD_ProcessJamCmd_Test_NoUpdateTableDwell(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_NoUpdateTableDwell */
+}
 
 void MD_ProcessJamCmd_Test_CantResolveJamAddr(void)
 {
@@ -687,8 +673,7 @@ void MD_ProcessJamCmd_Test_CantResolveJamAddr(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_CantResolveJamAddr */
+}
 
 void MD_ProcessJamCmd_Test_InvalidLenArg(void)
 {
@@ -730,8 +715,7 @@ void MD_ProcessJamCmd_Test_InvalidLenArg(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_InvalidLenArg */
+}
 
 void MD_ProcessJamCmd_Test_InvalidJamAddr(void)
 {
@@ -774,8 +758,7 @@ void MD_ProcessJamCmd_Test_InvalidJamAddr(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_InvalidJamAddr */
+}
 
 #if MD_ENFORCE_DWORD_ALIGN == 0
 void MD_ProcessJamCmd_Test_JamAddrNot16BitFieldLength4(void)
@@ -820,8 +803,7 @@ void MD_ProcessJamCmd_Test_JamAddrNot16BitFieldLength4(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_JamAddrNot16BitFieldLength4 */
+}
 #endif
 
 #if MD_ENFORCE_DWORD_ALIGN == 1
@@ -867,8 +849,7 @@ void MD_ProcessJamCmd_Test_JamAddrNot32Bit(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_JamAddrNot32Bit */
+}
 #endif
 
 void MD_ProcessJamCmd_Test_JamAddrNot16BitFieldLength2(void)
@@ -913,8 +894,7 @@ void MD_ProcessJamCmd_Test_JamAddrNot16BitFieldLength2(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_JamAddrNot16BitFieldLength2 */
+}
 
 void MD_ProcessJamCmd_Test_JamAddrNot16BitNot32Aligned(void)
 {
@@ -959,8 +939,7 @@ void MD_ProcessJamCmd_Test_JamAddrNot16BitNot32Aligned(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_JamAddrNot16BitNot32Aligned */
+}
 
 void MD_ProcessJamCmd_Test_JamFieldLength4Addr32Aligned(void)
 {
@@ -1004,8 +983,7 @@ void MD_ProcessJamCmd_Test_JamFieldLength4Addr32Aligned(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_JamFieldLength4Addr32Aligned */
+}
 
 void MD_ProcessJamCmd_Test_SuccessNonNullZeroRate(void)
 {
@@ -1072,8 +1050,7 @@ void MD_ProcessJamCmd_Test_SuccessNonNullZeroRate(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_SuccessNonNullZeroRate */
+}
 
 void MD_ProcessJamCmd_Test_SuccessZeroRateStreamDisabled(void)
 {
@@ -1126,8 +1103,7 @@ void MD_ProcessJamCmd_Test_SuccessZeroRateStreamDisabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_SuccessZeroRateStreamDisabled */
+}
 
 void MD_ProcessJamCmd_Test_SuccessRateNotZero(void)
 {
@@ -1182,8 +1158,7 @@ void MD_ProcessJamCmd_Test_SuccessRateNotZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessJamCmd_Test_SuccessRateNotZero */
+}
 
 #if MD_SIGNATURE_OPTION == 1
 void MD_ProcessSignatureCmd_Test_InvalidSignatureLength(void)
@@ -1221,8 +1196,7 @@ void MD_ProcessSignatureCmd_Test_InvalidSignatureLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessSignatureCmd_Test_InvalidSignatureLength */
+}
 #endif
 
 #if MD_SIGNATURE_OPTION == 1
@@ -1257,8 +1231,7 @@ void MD_ProcessSignatureCmd_Test_InvalidSignatureTable(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessSignatureCmd_Test_InvalidSignatureTable */
+}
 #endif
 
 #if MD_SIGNATURE_OPTION == 1
@@ -1302,8 +1275,7 @@ void MD_ProcessSignatureCmd_Test_Success(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessSignatureCmd_Test_Success */
+}
 #endif
 
 #if MD_SIGNATURE_OPTION == 1
@@ -1348,8 +1320,7 @@ void MD_ProcessSignatureCmd_Test_NoUpdateTableSignature(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ProcessSignatureCmd_Test_NoUpdateTableSignature */
+}
 #endif
 
 void UtTest_Setup(void)
@@ -1416,9 +1387,4 @@ void UtTest_Setup(void)
     UtTest_Add(MD_ProcessSignatureCmd_Test_NoUpdateTableSignature, MD_Test_Setup, MD_Test_TearDown,
                "MD_ProcessSignatureCmd_Test_NoUpdateTableSignature");
 #endif
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/md_dwell_pkt_tests.c
+++ b/unit-test/md_dwell_pkt_tests.c
@@ -90,8 +90,7 @@ void MD_DwellLoop_Test_PacketAlreadyFull(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_DwellLoop_Test_PacketAlreadyFull */
+}
 
 void MD_DwellLoop_Test_SendDwellPacket(void)
 {
@@ -156,8 +155,7 @@ void MD_DwellLoop_Test_SendDwellPacket(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_DwellLoop_Test_SendDwellPacket */
+}
 
 void MD_DwellLoop_Test_MoreAddressesToRead(void)
 {
@@ -216,8 +214,7 @@ void MD_DwellLoop_Test_MoreAddressesToRead(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_DwellLoop_Test_MoreAddressesToRead */
+}
 
 void MD_DwellLoop_Test_ZeroRate(void)
 {
@@ -282,8 +279,7 @@ void MD_DwellLoop_Test_ZeroRate(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_DwellLoop_Test_ZeroRate */
+}
 
 void MD_DwellLoop_Test_DataError(void)
 {
@@ -366,8 +362,7 @@ void MD_DwellLoop_Test_DataError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_DwellLoop_Test_DataError */
+}
 
 void MD_GetDwellData_Test_MemRead8Error(void)
 {
@@ -394,8 +389,7 @@ void MD_GetDwellData_Test_MemRead8Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_GetDwellData_Test_MemRead8Error */
+}
 
 void MD_GetDwellData_Test_MemRead16Error(void)
 {
@@ -422,8 +416,7 @@ void MD_GetDwellData_Test_MemRead16Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_GetDwellData_Test_MemRead16Error */
+}
 
 void MD_GetDwellData_Test_MemRead32Error(void)
 {
@@ -450,8 +443,7 @@ void MD_GetDwellData_Test_MemRead32Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_GetDwellData_Test_MemRead32Error */
+}
 
 void MD_GetDwellData_Test_InvalidDwellLength(void)
 {
@@ -475,8 +467,7 @@ void MD_GetDwellData_Test_InvalidDwellLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_GetDwellData_Test_InvalidDwellLength */
+}
 
 void MD_GetDwellData_Test_Success(void)
 {
@@ -500,8 +491,7 @@ void MD_GetDwellData_Test_Success(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_GetDwellData_Test_Success */
+}
 
 void MD_SendDwellPkt_Test(void)
 {
@@ -539,8 +529,7 @@ void MD_SendDwellPkt_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_SendDwellPkt_Test */
+}
 
 void MD_NoDwellRate_Test(void)
 {
@@ -578,8 +567,7 @@ void MD_NoDwellRate_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_NoDwellRate_Test */
+}
 
 void MD_StartDwellStream_Test(void)
 {
@@ -600,8 +588,7 @@ void MD_StartDwellStream_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_StartDwellStream_Test */
+}
 
 void UtTest_Setup(void)
 {
@@ -627,9 +614,4 @@ void UtTest_Setup(void)
     UtTest_Add(MD_SendDwellPkt_Test, MD_Test_Setup, MD_Test_TearDown, "MD_SendDwellPkt_Test");
     UtTest_Add(MD_NoDwellRate_Test, MD_Test_Setup, MD_Test_TearDown, "MD_NoDwellRate_Test");
     UtTest_Add(MD_StartDwellStream_Test, MD_Test_Setup, MD_Test_TearDown, "MD_StartDwellStream_Test");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/md_dwell_tbl_tests.c
+++ b/unit-test/md_dwell_tbl_tests.c
@@ -76,8 +76,7 @@ void MD_TableValidationFunc_Test_InvalidEnableFlag(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_InvalidEnableFlag */
+}
 
 #if MD_SIGNATURE_OPTION == 1
 void MD_TableValidationFunc_Test_InvalidSignatureLength(void)
@@ -110,8 +109,7 @@ void MD_TableValidationFunc_Test_InvalidSignatureLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_InvalidSignatureLength */
+}
 #endif
 
 void MD_TableValidationFunc_Test_ResolveError(void)
@@ -157,8 +155,7 @@ void MD_TableValidationFunc_Test_ResolveError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_ResolveError */
+}
 
 void MD_TableValidationFunc_Test_InvalidAddress(void)
 {
@@ -210,8 +207,7 @@ void MD_TableValidationFunc_Test_InvalidAddress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_InvalidAddress */
+}
 
 void MD_TableValidationFunc_Test_NullPtr(void)
 {
@@ -251,8 +247,7 @@ void MD_TableValidationFunc_Test_NullPtr(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_NullPtr */
+}
 
 void MD_TableValidationFunc_Test_InvalidLength(void)
 {
@@ -299,8 +294,7 @@ void MD_TableValidationFunc_Test_InvalidLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_InvalidLength */
+}
 
 void MD_TableValidationFunc_Test_NotAligned(void)
 {
@@ -349,8 +343,7 @@ void MD_TableValidationFunc_Test_NotAligned(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_NotAligned */
+}
 
 void MD_TableValidationFunc_Test_ZeroRate(void)
 {
@@ -402,8 +395,7 @@ void MD_TableValidationFunc_Test_ZeroRate(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_ZeroRate */
+}
 
 void MD_TableValidationFunc_Test_SuccessStreamDisabled(void)
 {
@@ -442,8 +434,7 @@ void MD_TableValidationFunc_Test_SuccessStreamDisabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_SuccessStreamDisabled */
+}
 
 void MD_TableValidationFunc_Test_Success(void)
 {
@@ -482,8 +473,7 @@ void MD_TableValidationFunc_Test_Success(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableValidationFunc_Test_Success */
+}
 
 void MD_ReadDwellTable_Test(void)
 {
@@ -514,8 +504,7 @@ void MD_ReadDwellTable_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ReadDwellTable_Test */
+}
 
 void MD_CheckTableEntries_Test_Error(void)
 {
@@ -562,8 +551,7 @@ void MD_CheckTableEntries_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_CheckTableEntries_Test_Error */
+}
 
 void MD_CheckTableEntries_Test_MultiError(void)
 {
@@ -602,8 +590,7 @@ void MD_CheckTableEntries_Test_MultiError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_CheckTableEntries_Test_Error */
+}
 
 void MD_CheckTableEntries_Test_Success(void)
 {
@@ -653,8 +640,7 @@ void MD_CheckTableEntries_Test_Success(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_CheckTableEntries_Test_Success */
+}
 
 void MD_ValidTableEntry_Test_SuccessDwellLengthZero(void)
 {
@@ -673,8 +659,7 @@ void MD_ValidTableEntry_Test_SuccessDwellLengthZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_SuccessDwellLengthZero */
+}
 
 void MD_ValidTableEntry_Test_ResolveError(void)
 {
@@ -696,8 +681,7 @@ void MD_ValidTableEntry_Test_ResolveError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_ResolveError */
+}
 
 void MD_ValidTableEntry_Test_InvalidAddress(void)
 {
@@ -720,8 +704,7 @@ void MD_ValidTableEntry_Test_InvalidAddress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_InvalidAddress */
+}
 
 void MD_ValidTableEntry_Test_InvalidLength(void)
 {
@@ -744,8 +727,7 @@ void MD_ValidTableEntry_Test_InvalidLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_InvalidLength */
+}
 
 #if MD_SIGNATURE_OPTION == 1
 void MD_ValidTableEntry_Test_NotAligned16DwellLength4(void)
@@ -770,8 +752,7 @@ void MD_ValidTableEntry_Test_NotAligned16DwellLength4(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_NotAligned16DwellLength4 */
+}
 
 void MD_ValidTableEntry_Test_Aligned32(void)
 {
@@ -797,8 +778,7 @@ void MD_ValidTableEntry_Test_Aligned32(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_Aligned32 */
+}
 
 void MD_ValidTableEntry_Test_NotAligned32(void)
 {
@@ -824,8 +804,7 @@ void MD_ValidTableEntry_Test_NotAligned32(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_NotAligned32 */
+}
 #endif
 
 #if MD_SIGNATURE_OPTION == 0
@@ -851,8 +830,7 @@ void MD_ValidTableEntry_Test_NotAligned32(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_NotAligned32 */
+}
 #endif
 
 void MD_ValidTableEntry_Test_NotAligned16DwellLength2(void)
@@ -878,8 +856,7 @@ void MD_ValidTableEntry_Test_NotAligned16DwellLength2(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_NotAligned16DwellLength2 */
+}
 
 void MD_ValidTableEntry_Test_ElseSuccess(void)
 {
@@ -904,8 +881,7 @@ void MD_ValidTableEntry_Test_ElseSuccess(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableEntry_Test_ElseSuccess */
+}
 
 void MD_CopyUpdatedTbl_Test(void)
 {
@@ -937,8 +913,7 @@ void MD_CopyUpdatedTbl_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_CopyUpdatedTbl_Test */
+}
 
 void MD_UpdateTableEnabledField_Test_DwellStreamEnabled(void)
 {
@@ -948,7 +923,7 @@ void MD_UpdateTableEnabledField_Test_DwellStreamEnabled(void)
     MD_DwellTableLoad_t *LoadTblPtr = &LoadTbl;
 
     /* Set MD_LoadTablePtr = &MD_DWELL_TBL_TEST_GlobalLoadTable */
-    // UT_SetHookFunction(UT_KEY(CFE_TBL_GetAddress), &MD_DWELL_TBL_TEST_CFE_TBL_GetAddressHook2, NULL);
+    /* UT_SetHookFunction(UT_KEY(CFE_TBL_GetAddress), &MD_DWELL_TBL_TEST_CFE_TBL_GetAddressHook2, NULL); */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
     LoadTblPtr->Enabled = MD_DWELL_STREAM_DISABLED;
 
@@ -964,8 +939,7 @@ void MD_UpdateTableEnabledField_Test_DwellStreamEnabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableEnabledField_Test_DwellStreamEnabled */
+}
 
 void MD_UpdateTableEnabledField_Test_DwellStreamDisabled(void)
 {
@@ -989,8 +963,7 @@ void MD_UpdateTableEnabledField_Test_DwellStreamDisabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableEnabledField_Test_DwellStreamDisabled */
+}
 
 void MD_UpdateTableEnabledField_Test_Error(void)
 {
@@ -1020,8 +993,7 @@ void MD_UpdateTableEnabledField_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableEnabledField_Test_Error */
+}
 
 void MD_UpdateTableDwellEntry_Test(void)
 {
@@ -1059,8 +1031,7 @@ void MD_UpdateTableDwellEntry_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableDwellEntry_Test */
+}
 
 void MD_UpdateTableDwellEntry_Test_Updated(void)
 {
@@ -1100,8 +1071,7 @@ void MD_UpdateTableDwellEntry_Test_Updated(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableDwellEntry_Test_Updated */
+}
 
 void MD_UpdateTableDwellEntry_Test_Error(void)
 {
@@ -1138,8 +1108,7 @@ void MD_UpdateTableDwellEntry_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableDwellEntry_Test_Error */
+}
 
 #if MD_SIGNATURE_OPTION == 1
 void MD_UpdateTableSignature_Test(void)
@@ -1163,8 +1132,7 @@ void MD_UpdateTableSignature_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableSignature_Test */
+}
 
 void MD_UpdateTableSignature_Test_Updated(void)
 {
@@ -1189,8 +1157,7 @@ void MD_UpdateTableSignature_Test_Updated(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableSignature_Test_Updated */
+}
 
 void MD_UpdateTableSignature_Test_Error(void)
 {
@@ -1220,8 +1187,7 @@ void MD_UpdateTableSignature_Test_Error(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateTableSignature_Test_Error */
+}
 
 #endif
 
@@ -1301,9 +1267,4 @@ void UtTest_Setup(void)
     UtTest_Add(MD_UpdateTableSignature_Test_Error, MD_Test_Setup, MD_Test_TearDown,
                "MD_UpdateTableSignature_Test_Error");
 #endif
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/md_utils_tests.c
+++ b/unit-test/md_utils_tests.c
@@ -58,8 +58,7 @@ void MD_TableIsInMask_Test_ShiftOddResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableIsInMask_Test_ShiftOddResult */
+}
 
 void MD_TableIsInMask_Test_ShiftEvenResult(void)
 {
@@ -77,8 +76,7 @@ void MD_TableIsInMask_Test_ShiftEvenResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableIsInMask_Test_ShiftEvenResult */
+}
 
 void MD_TableIsInMask_Test_TableNotInMask(void)
 {
@@ -96,8 +94,7 @@ void MD_TableIsInMask_Test_TableNotInMask(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_TableIsInMask_Test_TableNotInMask */
+}
 
 void MD_UpdateDwellControlInfo_Test(void)
 {
@@ -121,8 +118,7 @@ void MD_UpdateDwellControlInfo_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateDwellControlInfo_Test */
+}
 
 void MD_UpdateDwellControlInfo_TestAllTableEntries(void)
 {
@@ -150,8 +146,7 @@ void MD_UpdateDwellControlInfo_TestAllTableEntries(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_UpdateDwellControlInfo_TestAllTableEntries */
+}
 
 void MD_ValidEntryId_Test_Valid(void)
 {
@@ -168,8 +163,7 @@ void MD_ValidEntryId_Test_Valid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidEntryId_Test_Valid */
+}
 
 void MD_ValidEntryId_Test_Invalid(void)
 {
@@ -186,8 +180,7 @@ void MD_ValidEntryId_Test_Invalid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidEntryId_Test_Invalid */
+}
 
 void MD_ValidEntryId_Test_RangeError(void)
 {
@@ -204,8 +197,7 @@ void MD_ValidEntryId_Test_RangeError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidEntryId_Test_RangeError */
+}
 
 void MD_ValidAddrRange_Test_Valid(void)
 {
@@ -223,8 +215,7 @@ void MD_ValidAddrRange_Test_Valid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidAddrRange_Test_Valid */
+}
 
 void MD_ValidAddrRange_Test_Invalid(void)
 {
@@ -245,8 +236,7 @@ void MD_ValidAddrRange_Test_Invalid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidAddrRange_Test_Invalid */
+}
 
 void MD_ValidTableId_Test_Valid(void)
 {
@@ -263,8 +253,7 @@ void MD_ValidTableId_Test_Valid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableId_Test_Valid */
+}
 
 void MD_ValidTableId_Test_Invalid(void)
 {
@@ -281,8 +270,7 @@ void MD_ValidTableId_Test_Invalid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableId_Test_Invalid */
+}
 
 void MD_ValidTableId_Test_RangeError(void)
 {
@@ -299,8 +287,7 @@ void MD_ValidTableId_Test_RangeError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidTableId_Test_RangeError */
+}
 
 void MD_ValidFieldLength_Test_ValidFieldLength0(void)
 {
@@ -317,8 +304,7 @@ void MD_ValidFieldLength_Test_ValidFieldLength0(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidFieldLength_Test_ValidFieldLength0 */
+}
 
 void MD_ValidFieldLength_Test_ValidFieldLength1(void)
 {
@@ -335,8 +321,7 @@ void MD_ValidFieldLength_Test_ValidFieldLength1(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidFieldLength_Test_ValidFieldLength1 */
+}
 
 void MD_ValidFieldLength_Test_ValidFieldLength2(void)
 {
@@ -353,8 +338,7 @@ void MD_ValidFieldLength_Test_ValidFieldLength2(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidFieldLength_Test_ValidFieldLength2 */
+}
 
 void MD_ValidFieldLength_Test_ValidFieldLength4(void)
 {
@@ -371,8 +355,7 @@ void MD_ValidFieldLength_Test_ValidFieldLength4(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidFieldLength_Test_ValidFieldLength4 */
+}
 
 void MD_ValidFieldLength_Test_Invalid(void)
 {
@@ -389,8 +372,7 @@ void MD_ValidFieldLength_Test_Invalid(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
-} /* end MD_ValidFieldLength_Test_Invalid */
+}
 
 void MD_Verify32Aligned_Test(void)
 {
@@ -424,8 +406,7 @@ void MD_Verify32Aligned_Test(void)
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
-
-} /* end MD_Verify32Aligned_Test */
+}
 
 void MD_Verify16Aligned_Test(void)
 {
@@ -459,8 +440,7 @@ void MD_Verify16Aligned_Test(void)
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
-
-} /* end MD_Verify16Aligned_Test */
+}
 
 void MD_ResolveSymAddr_Test(void)
 {
@@ -539,9 +519,4 @@ void UtTest_Setup(void)
     UtTest_Add(MD_Verify16Aligned_Test, MD_Test_Setup, MD_Test_TearDown, "MD_Verify16Aligned_Test");
 
     UtTest_Add(MD_ResolveSymAddr_Test, MD_Test_Setup, MD_Test_TearDown, "MD_ResolveSymAddr_Test");
-
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #34
Removes redundant and inconsistent comments (e.g. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 