### PR TITLE
Fix #36, Apply consistent Event ID names to common events

### DIFF
--- a/fsw/inc/md_events.h
+++ b/fsw/inc/md_events.h
@@ -127,7 +127,7 @@
  *
  *  Issued upon receipt of a Memory Dwell Reset Counters command.
  */
-#define MD_RESET_CNTRS_DBG_EID 11
+#define MD_RESET_INF_EID 11
 
 /**
  * \brief MD Start Command Event ID
@@ -696,7 +696,7 @@
  *
  *  This event message is issued when MD cannot create the software bus pipe.
  */
-#define MD_CREATE_PIPE_ERR_EID 71
+#define MD_CR_PIPE_ERR_EID 71
 
 /**
  * \brief MD Housekeeping Subscribe Failed Event ID

--- a/fsw/inc/md_msgdefs.h
+++ b/fsw/inc/md_msgdefs.h
@@ -83,7 +83,7 @@
  *       the following telemetry:
  *       - #MD_HkTlm_Payload_t.ValidCmdCntr will be set to zero.
  *       - #MD_HkTlm_Payload_t.InvalidCmdCntr will be set to zero.
- *       - The #MD_RESET_CNTRS_DBG_EID debug event message will be generated.
+ *       - The #MD_RESET_INF_EID debug event message will be generated.
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):

--- a/fsw/src/md_app.c
+++ b/fsw/src/md_app.c
@@ -285,7 +285,7 @@ CFE_Status_t MD_InitSoftwareBusServices(void)
     }
     else
     {
-        CFE_EVS_SendEvent(MD_CREATE_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "Failed to create pipe.  RC = %d",
+        CFE_EVS_SendEvent(MD_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "Failed to create pipe.  RC = %d",
                           (unsigned int)Status);
     }
 
@@ -622,7 +622,7 @@ void MD_ExecRequest(const CFE_SB_Buffer_t *BufPtr)
 
             case MD_RESET_CNTRS_CC:
 
-                CFE_EVS_SendEvent(MD_RESET_CNTRS_DBG_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Cmd Received");
+                CFE_EVS_SendEvent(MD_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Cmd Received");
                 MD_AppData.CmdCounter = 0;
                 MD_AppData.ErrCounter = 0;
                 break;

--- a/unit-test/md_app_tests.c
+++ b/unit-test/md_app_tests.c
@@ -632,7 +632,7 @@ void MD_InitSoftwareBusServices_Test_CreatePipeError(void)
 
     UtAssert_True(Result == -1, "Result == -1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MD_CREATE_PIPE_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MD_CR_PIPE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1438,7 +1438,7 @@ void MD_ExecRequest_Test_ResetCounters(void)
     UtAssert_True(MD_AppData.CmdCounter == 0, "MD_AppData.CmdCounter == 0");
     UtAssert_True(MD_AppData.ErrCounter == 0, "MD_AppData.ErrCounter == 0");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MD_RESET_CNTRS_DBG_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MD_RESET_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #36 
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt