### PR TITLE
Fix #3, Add enum to remove magic number error codes from GetDwellData()

### DIFF
--- a/fsw/src/md_dwell_pkt.c
+++ b/fsw/src/md_dwell_pkt.c
@@ -84,7 +84,7 @@ void MD_DwellLoop(void)
                     /* Read data for next address and write it to dwell pkt */
                     Result = MD_GetDwellData(TblIndex, EntryIndex);
 
-                    if (Result == -1)
+                    if (Result != CFE_SUCCESS)
                     {
                         /* Send error event message */
                         CFE_EVS_SendEvent(MD_DWELL_LOOP_GET_DWELL_DATA_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -159,27 +159,27 @@ int32 MD_GetDwellData(uint16 TblIndex, uint16 EntryIndex)
     switch (NumBytes)
     {
         case 1:
-            if (CFE_PSP_MemRead8(DwellAddress, (uint8 *)&MemReadVal) != CFE_SUCCESS)
+            if (CFE_PSP_MemRead8(DwellAddress, (uint8 *)&MemReadVal) != CFE_PSP_SUCCESS)
             {
-                Status = -1;
+                Status = ONE_BYTE_MEM_ADDR_READ_ERR;
             }
             break;
         case 2:
-            if (CFE_PSP_MemRead16(DwellAddress, (uint16 *)&MemReadVal) != CFE_SUCCESS)
+            if (CFE_PSP_MemRead16(DwellAddress, (uint16 *)&MemReadVal) != CFE_PSP_SUCCESS)
             {
-                Status = -1;
+                Status = TWO_BYTE_MEM_ADDR_READ_ERR;
             }
             break;
         case 4:
-            if (CFE_PSP_MemRead32(DwellAddress, &MemReadVal) != CFE_SUCCESS)
+            if (CFE_PSP_MemRead32(DwellAddress, &MemReadVal) != CFE_PSP_SUCCESS)
             {
-                Status = -1;
+                Status = FOUR_BYTE_MEM_ADDR_READ_ERR;
             }
             break;
         default:
             /* Invalid dwell length */
             /* Shouldn't ever get here unless length value was corrupted. */
-            Status = -1;
+            Status = INVALID_DWELL_ADDR_LEN;
             break;
     }
 

--- a/fsw/src/md_dwell_pkt.h
+++ b/fsw/src/md_dwell_pkt.h
@@ -24,7 +24,45 @@
 #ifndef MD_DWELL_PKT_H
 #define MD_DWELL_PKT_H
 
+/************************************************************************
+ * Includes
+ ************************************************************************/
+
 #include "common_types.h"
+
+/************************************************************************
+ * Type Definitions
+ ************************************************************************/
+
+/**
+ *  \brief  MD enum used for representing error types of dwell address read
+ */
+enum MD_DwellAddrReadError
+{
+    /**
+     * @brief CFE_PSP_MemRead8 error
+     */
+    ONE_BYTE_MEM_ADDR_READ_ERR = -1,
+
+    /**
+     * @brief CFE_PSP_MemRead16 error
+     */
+    TWO_BYTE_MEM_ADDR_READ_ERR = -2,
+
+    /**
+     * @brief CFE_PSP_MemRead32 error
+     */
+    FOUR_BYTE_MEM_ADDR_READ_ERR = -3,
+
+    /**
+     * @brief Default case - Invalid Dwell Address length
+     */
+    INVALID_DWELL_ADDR_LEN = -4
+};
+
+/************************************************************************
+ * Exported Functions
+ ************************************************************************/
 
 /**
  * \brief Process Dwell Packets

--- a/unit-test/md_dwell_pkt_tests.c
+++ b/unit-test/md_dwell_pkt_tests.c
@@ -321,8 +321,8 @@ void MD_DwellLoop_Test_DataError(void)
     MD_AppData.MD_DwellTables[MD_NUM_DWELL_TABLES - 1].Entry[0].ResolvedAddress = 4;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead8), 1, -1);
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead16), 1, -1);
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead32), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead16), 1, -2);
+    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead32), 1, -3);
 
     /* Execute the function being tested */
     MD_DwellLoop();
@@ -401,7 +401,7 @@ void MD_GetDwellData_Test_MemRead16Error(void)
     MD_AppData.MD_DwellTables[TblIndex].PktOffset                = 0;
 
     /* Cause Status to be set to -1 */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead16), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead16), 1, -2);
 
     /* Execute the function being tested */
     Result = MD_GetDwellData(TblIndex, EntryIndex);
@@ -410,7 +410,7 @@ void MD_GetDwellData_Test_MemRead16Error(void)
     UtAssert_True(MD_AppData.MD_DwellTables[TblIndex].PktOffset == 2,
                   "MD_AppData.MD_DwellTables[TblIndex].PktOffset == 2");
 
-    UtAssert_True(Result == -1, "Result == -1");
+    UtAssert_True(Result == -2, "Result == -2");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -428,7 +428,7 @@ void MD_GetDwellData_Test_MemRead32Error(void)
     MD_AppData.MD_DwellTables[TblIndex].PktOffset                = 0;
 
     /* Cause Status to be set to -1 */
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead32), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemRead32), 1, -3);
 
     /* Execute the function being tested */
     Result = MD_GetDwellData(TblIndex, EntryIndex);
@@ -437,7 +437,7 @@ void MD_GetDwellData_Test_MemRead32Error(void)
     UtAssert_True(MD_AppData.MD_DwellTables[TblIndex].PktOffset == 4,
                   "MD_AppData.MD_DwellTables[TblIndex].PktOffset == 4");
 
-    UtAssert_True(Result == -1, "Result == -1");
+    UtAssert_True(Result == -3, "Result == -3");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -461,7 +461,7 @@ void MD_GetDwellData_Test_InvalidDwellLength(void)
     UtAssert_True(MD_AppData.MD_DwellTables[TblIndex].PktOffset == 5,
                   "MD_AppData.MD_DwellTables[TblIndex].PktOffset == 5");
 
-    UtAssert_True(Result == -1, "Result == -1");
+    UtAssert_True(Result == -4, "Result == -4");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/utilities/md_test_utils.c
+++ b/unit-test/utilities/md_test_utils.c
@@ -108,7 +108,7 @@ int32 CFE_PSP_MemWrite8(cpuaddr MemoryAddress, uint8 ByteValue)
 int32 CFE_PSP_MemRead16(cpuaddr MemoryAddress, uint16 *uint16Value)
 {
     if (!MemoryAddress)
-        return -1;
+        return -2;
     else
         return CFE_PSP_SUCCESS;
 }
@@ -124,7 +124,7 @@ int32 CFE_PSP_MemWrite16(cpuaddr MemoryAddress, uint16 uint16Value)
 int32 CFE_PSP_MemRead32(cpuaddr MemoryAddress, uint32 *uint32Value)
 {
     if (!MemoryAddress)
-        return -1;
+        return -3;
     else
         return CFE_PSP_SUCCESS;
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #3 
Adds enum to represent error return codes from dwell address read functions.

**Testing performed**
GitHub CI actions (incl. build + run, MD unit tests) all passing successfully.

**Expected behavior changes**
No change in logic.
Removes magic number error codes, making error types easier to identify.

**Contributor Info**
Avi Weiss @thnkslprpt