### PR TITLE
Fix #39, Remove initializations causing Cppcheck errors

### DIFF
--- a/fsw/src/md_cmds.c
+++ b/fsw/src/md_cmds.c
@@ -42,11 +42,11 @@ extern MD_AppData_t MD_AppData;
 
 void MD_ProcessStartCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    int32              ErrorCount      = 0;
-    int32              Status          = CFE_SUCCESS;
-    int32              NumTblInMask    = 0; /* Purely as info for event message */
-    uint16             TableId         = 0;
-    uint16             TableIndex      = 0;
+    int32              ErrorCount = 0;
+    int32              Status;
+    int32              NumTblInMask = 0; /* Purely as info for event message */
+    uint16             TableId      = 0;
+    uint16             TableIndex;
     MD_CmdStartStop_t *Start           = (MD_CmdStartStop_t *)BufPtr;
     bool               AnyTablesInMask = false;
 
@@ -130,12 +130,12 @@ void MD_ProcessStartCmd(const CFE_SB_Buffer_t *BufPtr)
 
 void MD_ProcessStopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    int32              ErrorCount      = 0;
-    int32              Status          = CFE_SUCCESS;
-    int32              NumTblInMask    = 0; /* Purely as info for event message */
-    MD_CmdStartStop_t *Stop            = (MD_CmdStartStop_t *)BufPtr;
-    uint16             TableId         = 0;
-    uint16             TableIndex      = 0;
+    int32              ErrorCount = 0;
+    int32              Status;
+    int32              NumTblInMask = 0; /* Purely as info for event message */
+    MD_CmdStartStop_t *Stop         = (MD_CmdStartStop_t *)BufPtr;
+    uint16             TableId      = 0;
+    uint16             TableIndex;
     bool               AnyTablesInMask = false;
 
     for (TableId = 1; TableId <= MD_NUM_DWELL_TABLES; TableId++)
@@ -192,13 +192,13 @@ void MD_ProcessStopCmd(const CFE_SB_Buffer_t *BufPtr)
 void MD_ProcessJamCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     /* Local variables */
-    int32                   Status         = CFE_SUCCESS;
+    int32                   Status;
     MD_CmdJam_t *           Jam            = 0;
     bool                    AllInputsValid = true;
     cpuaddr                 ResolvedAddr   = 0;
-    MD_DwellControlEntry_t *DwellEntryPtr  = 0; /* points to local task data */
-    uint16                  EntryIndex     = 0;
-    uint8                   TableIndex     = 0;
+    MD_DwellControlEntry_t *DwellEntryPtr; /* points to local task data */
+    uint16                  EntryIndex;
+    uint8                   TableIndex = 0;
     MD_SymAddr_t            NewDwellAddress;
 
     /*
@@ -407,7 +407,7 @@ void MD_ProcessJamCmd(const CFE_SB_Buffer_t *BufPtr)
 
 void MD_ProcessSignatureCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    int32                 Status       = CFE_SUCCESS;
+    int32                 Status;
     MD_CmdSetSignature_t *SignatureCmd = (MD_CmdSetSignature_t *)BufPtr;
     uint16                TblId        = 0;
     uint16                StringLength;

--- a/fsw/src/md_dwell_pkt.c
+++ b/fsw/src/md_dwell_pkt.c
@@ -37,11 +37,11 @@ extern MD_AppData_t MD_AppData;
 
 void MD_DwellLoop(void)
 {
-    int32                    Result = 0;
+    int32                    Result;
     uint16                   TblIndex;
-    uint16                   EntryIndex        = 0;
-    uint16                   NumDwellAddresses = 0;
-    MD_DwellPacketControl_t *TblPtr            = NULL;
+    uint16                   EntryIndex;
+    uint16                   NumDwellAddresses;
+    MD_DwellPacketControl_t *TblPtr = NULL;
 
     /* Check each dwell table */
     for (TblIndex = 0; TblIndex < MD_NUM_DWELL_TABLES; TblIndex++)

--- a/fsw/src/md_dwell_tbl.c
+++ b/fsw/src/md_dwell_tbl.c
@@ -171,7 +171,7 @@ int32 MD_ReadDwellTable(const MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCou
 /******************************************************************************/
 int32 MD_CheckTableEntries(MD_DwellTableLoad_t *TblPtr, uint16 *ErrorEntryArg)
 {
-    int32  Status         = CFE_SUCCESS;
+    int32  Status;
     int32  FirstErrorCode = CFE_SUCCESS;
     uint16 EntryIndex;
     int32  FirstBadIndex = -1;

--- a/fsw/src/md_utils.c
+++ b/fsw/src/md_utils.c
@@ -189,7 +189,7 @@ bool MD_Verify16Aligned(cpuaddr Address, uint32 Size)
 bool MD_ResolveSymAddr(MD_SymAddr_t *SymAddr, cpuaddr *ResolvedAddr)
 {
     bool  Valid;
-    int32 OS_Status = OS_SUCCESS;
+    int32 OS_Status;
 
     /*
     ** NUL terminate the very end of the symbol name string array as a


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #39 
Note: all are local variables only.
In order of the errors reported in the issue report:

md_cmds.c
In the `MD_ProcessStartCmd()` function:
`int32 Status = CFE_SUCCESS;`: `Status` only has a single use (on line 88) and it is assigned a value prior to this (on line 87), so this can safely be changed from an initialization to a declaration-only.
`uint16 TableIndex = 0;`: `TableIndex` is assigned a value (on line 80) before any and all of its references.

In the `MD_ProcessStopCmd()` function:
`int32 Status = CFE_SUCCESS;`: `Status` is assigned a value (on line 155) and is used only once on the next line. Given that this is a `void` function, there is no issue with this value being returned uninitialized if it doesn't get set somehow during the function logic or anything like that.
`uint16 TableIndex = 0;`: `TableIndex` is assigned a value (on line 146) before any and all of its references, so this can safely be converted from an initialization to a declaration-only at the top of the function.

In the `MD_ProcessJamCmd()` function:
`int32 Status = CFE_SUCCESS;`: `Status` is used twice in this function and is assigned a value both times on the immediately preceding line (on line 261, and later on line 358).
`MD_DwellControlEntry_t *DwellEntryPtr = 0;`: `DwellEntryPtr` is just initialized to `0`, so can't be used in this state anyway. Its variables are actually assigned values on line 246 and both of its uses are after this line and covered by it.
`uint16 EntryIndex = 0;`: `EntryIndex` is only used inside the if block which starts on line 241, and is assigned a value prior to any and all of its references on line 244.

In the `MD_ProcessSignatureCmd()` function:
`int32 Status = CFE_SUCCESS;`: `Status` is only used once (on line 458) and is assigned a value on the line immediately before this use.

md_dwell_pkt.c
`int32 Result = 0;`: `Result` is only used once (on line 86), and is assigned a value on the immediately preceding line.
`uint16 EntryIndex = 0;`: `EntryIndex` is assigned a value (on line 81) before any and all of its references.
`uint16 NumDwellAddresses = 0;`: `NumDwellAddresses` is assigned a value (on line 50) before any and all of its references.

md_dwell_tbl.c
`int32 Status = CFE_SUCCESS;`: `Status` is assigned a value (on line 192) and is only used in the mutually exclusive `if`/`else` block which immediately follows this assignment.

md_utils.c
`int32 OS_Status = OS_SUCCESS;`: `OS_Status` is only used once (on line 216) and is assigned a value on the immediately preceding line.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.
Cppcheck now passes without error again.

**Contributor Info**
Avi @thnkslprpt