### PR TITLE
Fix #48, Remove unintentionally repeated identical assert

### DIFF
--- a/unit-test/md_app_tests.c
+++ b/unit-test/md_app_tests.c
@@ -468,11 +468,6 @@ void MD_AppInit_Test_EvsRegisterNotSuccess(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
 }
 
 void MD_AppInit_Test_InitSoftwareBusServicesNotSuccess(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #48
  - Duplicate (identical) test removed.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.
Coverage unchanged:
```
  lines......: 100.0% (706 of 706 lines)
  functions..: 100.0% (36 of 36 functions)
  branches...: 100.0% (312 of 312 branches)
```

**Expected behavior changes**
Test code cleaner without unintentional (and redundant) duplicate assert.

**Contributor Info**
Avi Weiss @thnkslprpt