### PR TITLE
Fix #50, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,7 +3,7 @@ name: CodeQl Analysis
 on:
   push:
   pull_request:
-  
+
 
 jobs:
   codeql:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,4 @@ jobs:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with:
-      strict-dir-list: './fsw'    
+      strict-dir-list: './fsw'

--- a/docs/dox_src/cfs_md.dox
+++ b/docs/dox_src/cfs_md.dox
@@ -54,7 +54,7 @@
 
   This document provides a complete specification for the commands and telemetry associated
   with the CFS Memory Dwell (MD) application software.  The document is intended primarily 
-  for users of the software (operations personal, test engineers, and maintenance personal).  
+  for users of the software (operations personnel, test engineers, and maintenance personnel).  
   The deployment guide section, is intended for mission developers when deploying and 
   configuring the MD application software for a mission flight software build environment. 
 
@@ -117,7 +117,7 @@
     
     \section MD Design Overview 
 
-    MD is a command driven, single threaded application. It will pend indefinitely 
+    MD is a command-driven, single-threaded application. It will pend indefinitely 
     on the software bus message queue until messages arrive and then processes them sequentially.  
     Memory Dwell utilizes OSAL routines to:
 
@@ -304,7 +304,7 @@
          </B> <BR> <BR> <I>
             The first dwell always takes place when the first wakeup message is received following a 
             #MD_START_DWELL_CC command.  Dwelling proceeds until the first entry 
-            with a non-zero delay is reached. Thus, anytime a start command is sent for a dwell table 
+            with a non-zero delay is reached. Thus, any time a start command is sent for a dwell table 
             that does not have non-zero delays for intermediate entries, a dwell packet will be issued 
             immediately.  So, for example, a dwell table that is set up to sample several addresses 
             every 10 cycles, will actually issue dwell packets following the 1st, 11th, and 21st wakeup 

--- a/fsw/src/md_app.c
+++ b/fsw/src/md_app.c
@@ -54,7 +54,7 @@ MD_AppData_t MD_AppData;
 void MD_AppMain(void)
 {
     CFE_SB_MsgId_t   MessageID    = CFE_SB_INVALID_MSG_ID;
-    int32            Status       = CFE_SUCCESS;
+    CFE_Status_t     Status       = CFE_SUCCESS;
     uint8            TblIndex     = 0;
     CFE_SB_Buffer_t *BufPtr       = NULL;
     size_t           ActualLength = 0;
@@ -169,12 +169,12 @@ void MD_AppMain(void)
 
 /******************************************************************************/
 
-int32 MD_AppInit(void)
+CFE_Status_t MD_AppInit(void)
 {
     /*
     ** Locals
     */
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     MD_AppData.CmdCounter = 0;
     MD_AppData.ErrCounter = 0;
@@ -243,10 +243,10 @@ void MD_InitControlStructures(void)
 }
 
 /******************************************************************************/
-int32 MD_InitSoftwareBusServices(void)
+CFE_Status_t MD_InitSoftwareBusServices(void)
 {
-    int32  Status = CFE_SUCCESS;
-    uint16 TblIndex;
+    CFE_Status_t Status = CFE_SUCCESS;
+    uint16       TblIndex;
 
     /*
     ** Initialize housekeeping telemetry packet (clear user data area)
@@ -323,9 +323,9 @@ int32 MD_InitSoftwareBusServices(void)
 
 /******************************************************************************/
 
-int32 MD_InitTableServices(void)
+CFE_Status_t MD_InitTableServices(void)
 {
-    int32                Status           = CFE_SUCCESS;
+    CFE_Status_t         Status           = CFE_SUCCESS;
     int32                GetAddressResult = 0;
     uint8                TblIndex;
     bool                 RecoveredValidTable = true; /* for current table */
@@ -495,9 +495,9 @@ int32 MD_InitTableServices(void)
 }
 
 /******************************************************************************/
-int32 MD_ManageDwellTable(uint8 TblIndex)
+CFE_Status_t MD_ManageDwellTable(uint8 TblIndex)
 {
-    int32                Status           = CFE_SUCCESS;
+    CFE_Status_t         Status           = CFE_SUCCESS;
     int32                GetAddressResult = 0;
     bool                 FinishedManaging = false;
     MD_DwellTableLoad_t *MD_LoadTablePtr  = 0;

--- a/fsw/src/md_app.h
+++ b/fsw/src/md_app.h
@@ -170,7 +170,7 @@ void MD_AppMain(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MD_AppInit(void);
+CFE_Status_t MD_AppInit(void);
 
 /**
  * \brief Initialize local control structures
@@ -196,7 +196,7 @@ void MD_InitControlStructures(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MD_InitSoftwareBusServices(void);
+CFE_Status_t MD_InitSoftwareBusServices(void);
 
 /**
  * \brief Initialize Table Services for the Memory Dwell Task
@@ -220,7 +220,7 @@ int32 MD_InitSoftwareBusServices(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MD_InitTableServices(void);
+CFE_Status_t MD_InitTableServices(void);
 
 /**
  * \brief Check Table Status and take appropriate actions.
@@ -238,7 +238,7 @@ int32 MD_InitTableServices(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MD_ManageDwellTable(uint8 TblIndex);
+CFE_Status_t MD_ManageDwellTable(uint8 TblIndex);
 
 /**
  * \brief Execute requested Memory Dwell commands

--- a/fsw/src/md_cmds.c
+++ b/fsw/src/md_cmds.c
@@ -44,7 +44,7 @@ extern MD_AppData_t MD_AppData;
 void MD_ProcessStartCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     int32              ErrorCount = 0;
-    int32              Status;
+    CFE_Status_t       Status;
     int32              NumTblInMask = 0; /* Purely as info for event message */
     uint16             TableId      = 0;
     uint16             TableIndex;
@@ -132,7 +132,7 @@ void MD_ProcessStartCmd(const CFE_SB_Buffer_t *BufPtr)
 void MD_ProcessStopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     int32              ErrorCount = 0;
-    int32              Status;
+    CFE_Status_t       Status;
     int32              NumTblInMask = 0; /* Purely as info for event message */
     MD_CmdStartStop_t *Stop         = (MD_CmdStartStop_t *)BufPtr;
     uint16             TableId      = 0;
@@ -193,7 +193,7 @@ void MD_ProcessStopCmd(const CFE_SB_Buffer_t *BufPtr)
 void MD_ProcessJamCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     /* Local variables */
-    int32                   Status;
+    CFE_Status_t            Status;
     MD_CmdJam_t *           Jam            = 0;
     bool                    AllInputsValid = true;
     cpuaddr                 ResolvedAddr   = 0;
@@ -408,7 +408,7 @@ void MD_ProcessJamCmd(const CFE_SB_Buffer_t *BufPtr)
 
 void MD_ProcessSignatureCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    int32                 Status;
+    CFE_Status_t          Status;
     MD_CmdSetSignature_t *SignatureCmd = (MD_CmdSetSignature_t *)BufPtr;
     uint16                TblId        = 0;
     uint16                StringLength;

--- a/fsw/src/md_dwell_tbl.c
+++ b/fsw/src/md_dwell_tbl.c
@@ -150,7 +150,8 @@ int32 MD_TableValidationFunc(void *TblPtr)
 }
 
 /******************************************************************************/
-int32 MD_ReadDwellTable(const MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCountPtr, uint16 *SizePtr, uint32 *RatePtr)
+CFE_Status_t MD_ReadDwellTable(const MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCountPtr, uint16 *SizePtr,
+                               uint32 *RatePtr)
 {
     /* parameters cannot be NULL - checked by calling function */
 
@@ -332,11 +333,11 @@ void MD_CopyUpdatedTbl(MD_DwellTableLoad_t *MD_LoadTablePtr, uint8 TblIndex)
 }
 
 /******************************************************************************/
-int32 MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
+CFE_Status_t MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
 {
-    int32                Status          = CFE_SUCCESS;
+    CFE_Status_t         Status          = CFE_SUCCESS;
     MD_DwellTableLoad_t *MD_LoadTablePtr = NULL;
-    int32                GetAddressResult;
+    CFE_Status_t         GetAddressResult;
 
     GetAddressResult = CFE_TBL_GetAddress((void *)&MD_LoadTablePtr, MD_AppData.MD_TableHandle[TableIndex]);
 
@@ -363,11 +364,11 @@ int32 MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
 
 /******************************************************************************/
 
-int32 MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewLength, uint16 NewDelay,
-                               MD_SymAddr_t NewDwellAddress)
+CFE_Status_t MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewLength, uint16 NewDelay,
+                                      MD_SymAddr_t NewDwellAddress)
 {
-    int32                Status           = CFE_SUCCESS;
-    int32                GetAddressResult = 0;
+    CFE_Status_t         Status           = CFE_SUCCESS;
+    CFE_Status_t         GetAddressResult = 0;
     MD_DwellTableLoad_t *MD_LoadTablePtr  = NULL;
     MD_TableLoadEntry_t *EntryPtr         = NULL;
 
@@ -412,11 +413,11 @@ int32 MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewL
 /******************************************************************************/
 #if MD_SIGNATURE_OPTION == 1
 
-int32 MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIGNATURE_FIELD_LENGTH])
+CFE_Status_t MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIGNATURE_FIELD_LENGTH])
 {
-    int32                Status          = CFE_SUCCESS;
+    CFE_Status_t         Status          = CFE_SUCCESS;
     MD_DwellTableLoad_t *MD_LoadTablePtr = NULL;
-    int32                GetAddressResult;
+    CFE_Status_t         GetAddressResult;
 
     /* Get pointer to Table */
     GetAddressResult = CFE_TBL_GetAddress((void *)&MD_LoadTablePtr, MD_AppData.MD_TableHandle[TableIndex]);

--- a/fsw/src/md_dwell_tbl.h
+++ b/fsw/src/md_dwell_tbl.h
@@ -96,7 +96,7 @@ void MD_CopyUpdatedTbl(MD_DwellTableLoad_t *MD_LoadTablePtr, uint8 TblIndex);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue);
+CFE_Status_t MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue);
 
 /**
  * \brief Update Values for a Dwell Table Entry.
@@ -121,8 +121,8 @@ int32 MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewLength, uint16 NewDelay,
-                               MD_SymAddr_t NewDwellAddress);
+CFE_Status_t MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewLength, uint16 NewDelay,
+                                      MD_SymAddr_t NewDwellAddress);
 
 #if MD_SIGNATURE_OPTION == 1
 
@@ -142,7 +142,7 @@ int32 MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewL
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIGNATURE_FIELD_LENGTH]);
+CFE_Status_t MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIGNATURE_FIELD_LENGTH]);
 
 #endif
 
@@ -165,8 +165,8 @@ int32 MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIGNATURE_
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 MD_ReadDwellTable(const MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCountPtr, uint16 *SizePtr,
-                        uint32 *RatePtr);
+CFE_Status_t MD_ReadDwellTable(const MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCountPtr, uint16 *SizePtr,
+                               uint32 *RatePtr);
 
 /**
  * \brief Validate dwell table entry.

--- a/unit-test/md_app_tests.c
+++ b/unit-test/md_app_tests.c
@@ -43,8 +43,8 @@
 uint8               call_count_CFE_EVS_SendEvent;
 MD_DwellTableLoad_t MD_DWELL_TBL_TEST_GlobalLoadTable;
 
-int32 MD_DWELL_TBL_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
-                                               const UT_StubContext_t *Context)
+CFE_Status_t MD_DWELL_TBL_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                                      const UT_StubContext_t *Context)
 {
     void **TblPtr                             = (void **)Context->ArgPtr[0];
     MD_DWELL_TBL_TEST_GlobalLoadTable.Enabled = MD_DWELL_STREAM_ENABLED;
@@ -411,9 +411,9 @@ void MD_AppMain_Test_InvalidMessageID(void)
 
 void MD_AppInit_Test_Nominal(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "MD Initialized.  Version %%d.%%d.%%d.%%d");
 
@@ -445,9 +445,9 @@ void MD_AppInit_Test_Nominal(void)
 
 void MD_AppInit_Test_EvsRegisterNotSuccess(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedSysLogString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "MD_APP:Call to CFE_EVS_Register Failed:RC=%%d\n");
 
@@ -477,7 +477,7 @@ void MD_AppInit_Test_EvsRegisterNotSuccess(void)
 
 void MD_AppInit_Test_InitSoftwareBusServicesNotSuccess(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to make MD_InitSoftwareBusServices return -1 */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_CreatePipe), 1, -1);
@@ -498,7 +498,7 @@ void MD_AppInit_Test_InitSoftwareBusServicesNotSuccess(void)
 
 void MD_AppInit_Test_InitTableServicesNotSuccess(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Set to make MD_InitTableServices return -1 */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_Register), 1, -1);
@@ -607,7 +607,7 @@ void MD_InitControlStructures_Test(void)
 
 void MD_InitSoftwareBusServices_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Execute the function being tested */
     Result = MD_InitSoftwareBusServices();
@@ -631,9 +631,9 @@ void MD_InitSoftwareBusServices_Test_Nominal(void)
 
 void MD_InitSoftwareBusServices_Test_CreatePipeError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Failed to create pipe.  RC = %%d");
 
@@ -669,9 +669,9 @@ void MD_InitSoftwareBusServices_Test_CreatePipeError(void)
 
 void MD_InitSoftwareBusServices_Test_SubscribeHkError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Failed to subscribe to HK requests  RC = %%d");
 
@@ -707,9 +707,9 @@ void MD_InitSoftwareBusServices_Test_SubscribeHkError(void)
 
 void MD_InitSoftwareBusServices_Test_SubscribeCmdError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Failed to subscribe to commands.  RC = %%d");
 
@@ -745,9 +745,9 @@ void MD_InitSoftwareBusServices_Test_SubscribeCmdError(void)
 
 void MD_InitSoftwareBusServices_Test_SubscribeWakeupError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Failed to subscribe to wakeup messages.  RC = %%d");
@@ -784,10 +784,10 @@ void MD_InitSoftwareBusServices_Test_SubscribeWakeupError(void)
 
 void MD_InitTableServices_Test_GetAddressErrorAndLoadError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    char  ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    char         ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Didn't update MD tbl #%%d due to unexpected CFE_TBL_GetAddress return: 0x%%08X");
@@ -852,9 +852,9 @@ void MD_InitTableServices_Test_GetAddressErrorAndLoadError(void)
 
 void MD_InitTableServices_Test_TblRecoveredValidThenTblInits(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[4][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[4][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Dwell Tables Recovered: %%d, Dwell Tables Initialized: %%d");
@@ -897,7 +897,7 @@ void MD_InitTableServices_Test_TblRecoveredValidThenTblInits(void)
 
 void MD_InitTableServices_Test_TblRecoveredNotValid(void)
 {
-    int32                Result;
+    CFE_Status_t         Result;
     int32                strCmpResult;
     char                 ExpectedEventString[4][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     MD_DwellTableLoad_t  LoadTbl;
@@ -963,7 +963,7 @@ void MD_InitTableServices_Test_TblRecoveredNotValid(void)
 
 void MD_InitTableServices_Test_DwellStreamEnabled(void)
 {
-    int32                Result;
+    CFE_Status_t         Result;
     int32                strCmpResult;
     char                 ExpectedEventString[4][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     MD_DwellTableLoad_t  LoadTbl;
@@ -1027,7 +1027,7 @@ void MD_InitTableServices_Test_DwellStreamEnabled(void)
 
 void MD_InitTableServices_Test_TblNotRecovered(void)
 {
-    int32                Result;
+    CFE_Status_t         Result;
     int32                strCmpResult;
     char                 ExpectedEventString[4][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     MD_DwellTableLoad_t  LoadTbl;
@@ -1089,9 +1089,9 @@ void MD_InitTableServices_Test_TblNotRecovered(void)
 
 void MD_InitTableServices_Test_TblTooLarge(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Dwell Table(s) are too large to register: %%u bytes, %%d entries");
@@ -1135,9 +1135,9 @@ void MD_InitTableServices_Test_TblTooLarge(void)
 
 void MD_InitTableServices_Test_TblRegisterCriticalError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CFE_TBL_Register error %%d received for tbl#%%d");
@@ -1256,8 +1256,8 @@ void MD_InitTableServices_Test_TblFileNameError(void)
 
 void MD_ManageDwellTable_Test_ValidationPendingSucceedThenFail(void)
 {
-    int32 Result;
-    uint8 TblIndex = 0;
+    CFE_Status_t Result;
+    uint8        TblIndex = 0;
 
     /* Set to satisfy condition "Status == CFE_TBL_INFO_VALIDATION_PENDING" */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetStatus), CFE_TBL_INFO_VALIDATION_PENDING);
@@ -1279,7 +1279,7 @@ void MD_ManageDwellTable_Test_ValidationPendingSucceedThenFail(void)
 
 void MD_ManageDwellTable_Test_UpdatePendingDwellStreamEnabled(void)
 {
-    int32                Result;
+    CFE_Status_t         Result;
     uint8                TblIndex = 0;
     MD_DwellTableLoad_t  LoadTbl;
     MD_DwellTableLoad_t *LoadTblPtr = &LoadTbl;
@@ -1312,7 +1312,7 @@ void MD_ManageDwellTable_Test_UpdatePendingDwellStreamEnabled(void)
 
 void MD_ManageDwellTable_Test_UpdatePendingDwellStreamDisabled(void)
 {
-    int32                Result;
+    CFE_Status_t         Result;
     uint8                TblIndex = 0;
     MD_DwellTableLoad_t  LoadTbl;
     MD_DwellTableLoad_t *LoadTblPtr = &LoadTbl;
@@ -1347,8 +1347,8 @@ void MD_ManageDwellTable_Test_UpdatePendingDwellStreamDisabled(void)
 
 void MD_ManageDwellTable_Test_TblNotUpdated(void)
 {
-    int32 Result;
-    uint8 TblIndex = 0;
+    CFE_Status_t Result;
+    uint8        TblIndex = 0;
 
     /* Set to satisfy condition "Status == CFE_TBL_INFO_UPDATE_PENDING" */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetStatus), 1, CFE_TBL_INFO_UPDATE_PENDING);
@@ -1375,10 +1375,10 @@ void MD_ManageDwellTable_Test_TblNotUpdated(void)
 
 void MD_ManageDwellTable_Test_UpdatePendingTblCopyError(void)
 {
-    int32 Result;
-    uint8 TblIndex = 0;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    uint8        TblIndex = 0;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Didn't update MD tbl #%%d due to unexpected CFE_TBL_GetAddress return: %%d");
@@ -1410,10 +1410,10 @@ void MD_ManageDwellTable_Test_UpdatePendingTblCopyError(void)
 
 void MD_ManageDwellTable_Test_TblStatusErr(void)
 {
-    int32 Result;
-    uint8 TblIndex = 0;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    uint8        TblIndex = 0;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Received unexpected error %%d from CFE_TBL_GetStatus for tbl #%%d");
@@ -1442,8 +1442,8 @@ void MD_ManageDwellTable_Test_TblStatusErr(void)
 
 void MD_ManageDwellTable_Test_OtherStatus(void)
 {
-    int32 Result;
-    uint8 TblIndex = 0;
+    CFE_Status_t Result;
+    uint8        TblIndex = 0;
 
     /* Set to reach final else-case */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetStatus), 1, 99);

--- a/unit-test/md_cmds_tests.c
+++ b/unit-test/md_cmds_tests.c
@@ -45,8 +45,8 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-int32 MD_CMDS_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
-                                          const UT_StubContext_t *Context)
+CFE_Status_t MD_CMDS_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                                 const UT_StubContext_t *Context)
 {
     void **TblPtr = (void **)Context->ArgPtr[0];
 

--- a/unit-test/md_dwell_tbl_tests.c
+++ b/unit-test/md_dwell_tbl_tests.c
@@ -477,7 +477,7 @@ void MD_TableValidationFunc_Test_Success(void)
 
 void MD_ReadDwellTable_Test(void)
 {
-    int32               Result;
+    CFE_Status_t        Result;
     MD_DwellTableLoad_t Table;
     uint16              i;
     uint16              ActiveAddrCount = 0;

--- a/unit-test/stubs/md_app_stubs.c
+++ b/unit-test/stubs/md_app_stubs.c
@@ -40,7 +40,7 @@ void MD_AppMain(void)
     UT_DEFAULT_IMPL(MD_AppMain);
 }
 
-int32 MD_AppInit(void)
+CFE_Status_t MD_AppInit(void)
 {
     return UT_DEFAULT_IMPL(MD_AppInit);
 }
@@ -50,17 +50,17 @@ void MD_InitControlStructures(void)
     UT_DEFAULT_IMPL(MD_InitControlStructures);
 }
 
-int32 MD_InitSoftwareBusServices(void)
+CFE_Status_t MD_InitSoftwareBusServices(void)
 {
     return UT_DEFAULT_IMPL(MD_InitSoftwareBusServices);
 }
 
-int32 MD_InitTableServices(void)
+CFE_Status_t MD_InitTableServices(void)
 {
     return UT_DEFAULT_IMPL(MD_InitTableServices);
 }
 
-int32 MD_ManageDwellTable(uint8 TblIndex)
+CFE_Status_t MD_ManageDwellTable(uint8 TblIndex)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_ManageDwellTable), TblIndex);
     return UT_DEFAULT_IMPL(MD_ManageDwellTable);

--- a/unit-test/stubs/md_dwell_tbl_stubs.c
+++ b/unit-test/stubs/md_dwell_tbl_stubs.c
@@ -42,15 +42,15 @@ void MD_CopyUpdatedTbl(MD_DwellTableLoad_t *MD_LoadTablePtr, uint8 TblIndex)
     UT_DEFAULT_IMPL(MD_CopyUpdatedTbl);
 }
 
-int32 MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
+CFE_Status_t MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_UpdateTableEnabledField), TableIndex);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_UpdateTableEnabledField), FieldValue);
     return UT_DEFAULT_IMPL(MD_UpdateTableEnabledField);
 }
 
-int32 MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewLength, uint16 NewDelay,
-                               MD_SymAddr_t NewDwellAddress)
+CFE_Status_t MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewLength, uint16 NewDelay,
+                                      MD_SymAddr_t NewDwellAddress)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_UpdateTableDwellEntry), TableIndex);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_UpdateTableDwellEntry), EntryIndex);
@@ -60,14 +60,15 @@ int32 MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewL
     return UT_DEFAULT_IMPL(MD_UpdateTableDwellEntry);
 }
 
-int32 MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIGNATURE_FIELD_LENGTH])
+CFE_Status_t MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIGNATURE_FIELD_LENGTH])
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_UpdateTableSignature), TableIndex);
     UT_Stub_RegisterContext(UT_KEY(MD_UpdateTableSignature), NewSignature);
     return UT_DEFAULT_IMPL(MD_UpdateTableSignature);
 }
 
-int32 MD_ReadDwellTable(MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCountPtr, uint16 *SizePtr, uint32 *RatePtr)
+CFE_Status_t MD_ReadDwellTable(MD_DwellTableLoad_t *TblPtr, uint16 *ActiveAddrCountPtr, uint16 *SizePtr,
+                               uint32 *RatePtr)
 {
     UT_Stub_RegisterContext(UT_KEY(MD_ReadDwellTable), TblPtr);
     UT_Stub_RegisterContext(UT_KEY(MD_ReadDwellTable), ActiveAddrCountPtr);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #50
  - most `int32` return codes converted over to `CFE_Status_t`
  - `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t`

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt