### PR TITLE
Fix #52, Combine consecutive, mutually-exclusive status checks

### DIFF
--- a/fsw/src/md_app.c
+++ b/fsw/src/md_app.c
@@ -185,17 +185,16 @@ int32 MD_AppInit(void)
     /* Register for event services...*/
     Status = CFE_EVS_Register(NULL, 0, CFE_EVS_NO_FILTER);
 
-    if (Status != CFE_SUCCESS)
-    {
-        CFE_ES_WriteToSysLog("MD_APP:Call to CFE_EVS_Register Failed:RC=%d\n", Status);
-    }
-
-    /*
-    ** Set up for Software Bus Services
-    */
     if (Status == CFE_SUCCESS)
     {
+        /*
+        ** Set up for Software Bus Services
+        */
         Status = MD_InitSoftwareBusServices();
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("MD_APP:Call to CFE_EVS_Register Failed:RC=%d\n", Status);
     }
 
     /*
@@ -271,16 +270,11 @@ int32 MD_InitSoftwareBusServices(void)
     */
     Status = CFE_SB_CreatePipe(&MD_AppData.CmdPipe, MD_PIPE_DEPTH, MD_PIPE_NAME);
 
-    if (Status != CFE_SUCCESS)
-    {
-        CFE_EVS_SendEvent(MD_CREATE_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "Failed to create pipe.  RC = %d", Status);
-    }
-
-    /*
-    ** Subscribe to Housekeeping request commands
-    */
     if (Status == CFE_SUCCESS)
     {
+        /*
+         ** Subscribe to Housekeeping request commands
+         */
         Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(MD_SEND_HK_MID), MD_AppData.CmdPipe);
 
         if (Status != CFE_SUCCESS)
@@ -288,6 +282,10 @@ int32 MD_InitSoftwareBusServices(void)
             CFE_EVS_SendEvent(MD_SUB_HK_ERR_EID, CFE_EVS_EventType_ERROR, "Failed to subscribe to HK requests  RC = %d",
                               Status);
         }
+    }
+    else
+    {
+        CFE_EVS_SendEvent(MD_CREATE_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "Failed to create pipe.  RC = %d", Status);
     }
 
     /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #52
  - Consecutive, mutually-exclusive status checks combined into a single `if`/`else`.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt