### PR TITLE
Fix #54, Combine multiple unnecessary `status`/`result` variables

### DIFF
--- a/fsw/src/md_dwell_tbl.c
+++ b/fsw/src/md_dwell_tbl.c
@@ -337,16 +337,14 @@ CFE_Status_t MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
 {
     CFE_Status_t         Status          = CFE_SUCCESS;
     MD_DwellTableLoad_t *MD_LoadTablePtr = NULL;
-    CFE_Status_t         GetAddressResult;
 
-    GetAddressResult = CFE_TBL_GetAddress((void *)&MD_LoadTablePtr, MD_AppData.MD_TableHandle[TableIndex]);
+    Status = CFE_TBL_GetAddress((void *)&MD_LoadTablePtr, MD_AppData.MD_TableHandle[TableIndex]);
 
-    if ((GetAddressResult != CFE_SUCCESS) && (GetAddressResult != CFE_TBL_INFO_UPDATED))
+    if ((Status != CFE_SUCCESS) && (Status != CFE_TBL_INFO_UPDATED))
     {
         CFE_EVS_SendEvent(MD_UPDATE_TBL_EN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "MD_UpdateTableEnabledField, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x", TableIndex,
-                          GetAddressResult);
-        Status = GetAddressResult;
+                          Status);
     }
     else
     {
@@ -367,20 +365,18 @@ CFE_Status_t MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
 CFE_Status_t MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint16 NewLength, uint16 NewDelay,
                                       MD_SymAddr_t NewDwellAddress)
 {
-    CFE_Status_t         Status           = CFE_SUCCESS;
-    CFE_Status_t         GetAddressResult = 0;
-    MD_DwellTableLoad_t *MD_LoadTablePtr  = NULL;
-    MD_TableLoadEntry_t *EntryPtr         = NULL;
+    CFE_Status_t         Status          = CFE_SUCCESS;
+    MD_DwellTableLoad_t *MD_LoadTablePtr = NULL;
+    MD_TableLoadEntry_t *EntryPtr        = NULL;
 
     /* Get pointer to Table */
-    GetAddressResult = CFE_TBL_GetAddress((void *)&MD_LoadTablePtr, MD_AppData.MD_TableHandle[TableIndex]);
+    Status = CFE_TBL_GetAddress((void *)&MD_LoadTablePtr, MD_AppData.MD_TableHandle[TableIndex]);
 
-    if ((GetAddressResult != CFE_SUCCESS) && (GetAddressResult != CFE_TBL_INFO_UPDATED))
+    if ((Status != CFE_SUCCESS) && (Status != CFE_TBL_INFO_UPDATED))
     {
         CFE_EVS_SendEvent(MD_UPDATE_TBL_DWELL_ERR_EID, CFE_EVS_EventType_ERROR,
                           "MD_UpdateTableDwellEntry, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x", TableIndex,
-                          GetAddressResult);
-        Status = GetAddressResult;
+                          Status);
     }
     else
     {
@@ -417,17 +413,15 @@ CFE_Status_t MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIG
 {
     CFE_Status_t         Status          = CFE_SUCCESS;
     MD_DwellTableLoad_t *MD_LoadTablePtr = NULL;
-    CFE_Status_t         GetAddressResult;
 
     /* Get pointer to Table */
-    GetAddressResult = CFE_TBL_GetAddress((void *)&MD_LoadTablePtr, MD_AppData.MD_TableHandle[TableIndex]);
+    Status = CFE_TBL_GetAddress((void *)&MD_LoadTablePtr, MD_AppData.MD_TableHandle[TableIndex]);
 
-    if ((GetAddressResult != CFE_SUCCESS) && (GetAddressResult != CFE_TBL_INFO_UPDATED))
+    if ((Status != CFE_SUCCESS) && (Status != CFE_TBL_INFO_UPDATED))
     {
         CFE_EVS_SendEvent(MD_UPDATE_TBL_SIG_ERR_EID, CFE_EVS_EventType_ERROR,
                           "MD_UpdateTableSignature, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x", TableIndex,
-                          GetAddressResult);
-        Status = GetAddressResult;
+                          Status);
     }
     else
     {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #54
  - 3 cases of multiple unnecessary `status`/`result` variables holding returns from `CFE_TBL_GetAddress()` have been combined

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to functional behavior.
Code is simplified - improving future maintainability.

**Contributor Info**
Avi Weiss @thnkslprpt