### PR TITLE
Fix #59, remove unneeded stack object

### DIFF
--- a/fsw/src/md_app.c
+++ b/fsw/src/md_app.c
@@ -328,15 +328,10 @@ CFE_Status_t MD_InitTableServices(void)
     uint8                TblIndex;
     bool                 RecoveredValidTable = true; /* for current table */
     bool                 TableInitValidFlag  = true; /* for all tables so far*/
-    MD_DwellTableLoad_t  InitMemDwellTable;
-    MD_DwellTableLoad_t *MD_LoadTablePtr = NULL;
-    uint16               TblRecos        = 0; /* Number of Tables Recovered */
-    uint16               TblInits        = 0; /* Number of Tables Initialized */
+    MD_DwellTableLoad_t *MD_LoadTablePtr     = NULL;
+    uint16               TblRecos            = 0; /* Number of Tables Recovered */
+    uint16               TblInits            = 0; /* Number of Tables Initialized */
     char                 TblFileName[OS_MAX_PATH_LEN];
-
-    /*  Prepare Data Structure used for loading Initial Table Data    */
-
-    memset(&InitMemDwellTable, 0, sizeof(InitMemDwellTable));
 
     /*
     ** For each table, load recovered data if available and valid.


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/MD/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Remove the Initial dwell table object from MD_InitTableServices. This object was not actually used, and consumed several kB of stack space unnecessarily, depending on the size of the table.

Fixes #59

**Testing performed**
Run MD in sample config

**Expected behavior changes**
Peak stack use decreases by about 2kB (which is `sizeof(MD_DwellTableLoad_t)`)

**System(s) tested on**
Debian

**Additional context**
This extra object made it more likely for MD to overrun its stack during startup vs other similar CFS apps.  This was particularly the case where small stack sizes were used (e.g. 8kB).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
