### PR TITLE
Fix #5, Use `CFE_MSG_PTR` instead of `&(x).Msg`

### DIFF
--- a/fsw/inc/md_msg.h
+++ b/fsw/inc/md_msg.h
@@ -95,7 +95,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< Command Header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< Command Header */
 } MD_NoArgsCmd_t;
 
 /**
@@ -105,7 +105,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t   Header; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command header */
     MD_CmdStartStop_Payload_t Payload;
 } MD_CmdStartStop_t;
 
@@ -116,7 +116,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t Header; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
     MD_CmdJam_Payload_t     Payload;
 } MD_CmdJam_t;
 
@@ -129,7 +129,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t      Header; /**< \brief Command Header */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command Header */
     MD_CmdSetSignature_Payload_t Payload;
 } MD_CmdSetSignature_t;
 
@@ -182,7 +182,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry header */
     MD_HkTlm_Payload_t        Payload;
 } MD_HkTlm_t;
 
@@ -196,7 +196,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry header */
     MD_DwellPkt_Payload_t     Payload;
 } MD_DwellPkt_t;
 

--- a/fsw/src/md_app.c
+++ b/fsw/src/md_app.c
@@ -250,13 +250,13 @@ CFE_Status_t MD_InitSoftwareBusServices(void)
     /*
     ** Initialize housekeeping telemetry packet (clear user data area)
     */
-    CFE_MSG_Init(&MD_AppData.HkPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(MD_HK_TLM_MID), MD_HK_TLM_LNGTH);
+    CFE_MSG_Init(CFE_MSG_PTR(MD_AppData.HkPkt.TelemetryHeader), CFE_SB_ValueToMsgId(MD_HK_TLM_MID), MD_HK_TLM_LNGTH);
     /*
     ** Initialize dwell packets (clear user data area)
     */
     for (TblIndex = 0; TblIndex < MD_NUM_DWELL_TABLES; TblIndex++)
     {
-        CFE_MSG_Init(&MD_AppData.MD_DwellPkt[TblIndex].TlmHeader.Msg,
+        CFE_MSG_Init(CFE_MSG_PTR(MD_AppData.MD_DwellPkt[TblIndex].TelemetryHeader),
                      CFE_SB_ValueToMsgId(MD_DWELL_PKT_MID_BASE + TblIndex),
                      MD_DWELL_PKT_LNGTH); /* this is max pkt size */
 
@@ -699,8 +699,8 @@ void MD_HkStatus()
     /*
     ** Send housekeeping telemetry packet...
     */
-    CFE_SB_TimeStampMsg(&HkPktPtr->TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&HkPktPtr->TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(HkPktPtr->TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(HkPktPtr->TelemetryHeader), true);
 }
 
 /******************************************************************************/

--- a/fsw/src/md_dwell_pkt.c
+++ b/fsw/src/md_dwell_pkt.c
@@ -226,13 +226,13 @@ void MD_SendDwellPkt(uint16 TableIndex)
 
     DwellPktSize = MD_DWELL_PKT_LNGTH - MD_DWELL_TABLE_SIZE * 4 + TblPtr->DataSize;
 
-    CFE_MSG_SetSize(&PktPtr->TlmHeader.Msg, DwellPktSize);
+    CFE_MSG_SetSize(CFE_MSG_PTR(PktPtr->TelemetryHeader), DwellPktSize);
 
     /*
     ** Send dwell telemetry packet.
     */
-    CFE_SB_TimeStampMsg(&PktPtr->TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&PktPtr->TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(PktPtr->TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(PktPtr->TelemetryHeader), true);
 }
 
 /******************************************************************************/


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #5
  - Local unwrappings replaced with the abstracted `CFE_MSG_PTR` macro
  - Minor related naming convention updates:
    - `CmdHeader` renamed to `CommandHeader`
    - `TlmHeader` renamed to `TelemetryHeader`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt