### PR TITLE
Fix 69, Coverage not 100% when Signature option set to 0

### DIFF
--- a/unit-test/md_dwell_tbl_tests.c
+++ b/unit-test/md_dwell_tbl_tests.c
@@ -729,7 +729,6 @@ void MD_ValidTableEntry_Test_InvalidLength(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-#if MD_SIGNATURE_OPTION == 1
 void MD_ValidTableEntry_Test_NotAligned16DwellLength4(void)
 {
     int32               Result;
@@ -805,33 +804,6 @@ void MD_ValidTableEntry_Test_NotAligned32(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
-
-#if MD_SIGNATURE_OPTION == 0
-void MD_ValidTableEntry_Test_NotAligned32(void)
-{
-    int32               Result;
-    MD_TableLoadEntry_t Entry;
-
-    Entry.Length              = 4;
-    Entry.DwellAddress.Offset = 1;
-
-    UT_SetDefaultReturnValue(UT_KEY(MD_ResolveSymAddr), true);
-    UT_SetDefaultReturnValue(UT_KEY(MD_ValidAddrRange), true);
-    UT_SetDefaultReturnValue(UT_KEY(MD_ValidFieldLength), false);
-
-    /* Execute the function being tested */
-    Result = MD_ValidTableEntry(&Entry);
-
-    /* Verify results */
-    UtAssert_True(Result == MD_NOT_ALIGNED_ERROR, "Result == MD_NOT_ALIGNED_ERROR");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-#endif
 
 void MD_ValidTableEntry_Test_NotAligned16DwellLength2(void)
 {
@@ -1231,8 +1203,6 @@ void UtTest_Setup(void)
                "MD_ValidTableEntry_Test_InvalidAddress");
     UtTest_Add(MD_ValidTableEntry_Test_InvalidLength, MD_Test_Setup, MD_Test_TearDown,
                "MD_ValidTableEntry_Test_InvalidLength");
-
-#if MD_SIGNATURE_OPTION == 1
     UtTest_Add(MD_ValidTableEntry_Test_NotAligned16DwellLength4, MD_Test_Setup, MD_Test_TearDown,
                "MD_ValidTableEntry_Test_NotAligned16DwellLength4");
     UtTest_Add(MD_ValidTableEntry_Test_Aligned32, MD_Test_Setup, MD_Test_TearDown, "MD_ValidTableEntry_Test_Aligned32");
@@ -1240,8 +1210,6 @@ void UtTest_Setup(void)
                "MD_ValidTableEntry_Test_NotAligned32");
     UtTest_Add(MD_ValidTableEntry_Test_NotAligned16DwellLength2, MD_Test_Setup, MD_Test_TearDown,
                "MD_ValidTableEntry_Test_NotAligned16DwellLength2");
-#endif
-
     UtTest_Add(MD_ValidTableEntry_Test_ElseSuccess, MD_Test_Setup, MD_Test_TearDown,
                "MD_ValidTableEntry_Test_ElseSuccess");
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/MD/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Improves MD code coverage when MD_SIGNATURE_OPTION set to 0 - Fixes #69 

**Testing performed**
Executed coverage tests with and without MD_SIGNATURE_OPTION to ensure 100% coverage

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA/Goddard
