### PR TITLE
Fix #72, Update Reset Counters event type to `INFORMATION`

### DIFF
--- a/fsw/inc/md_events.h
+++ b/fsw/inc/md_events.h
@@ -121,7 +121,7 @@
 /**
  * \brief MD Reset Counters Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *

--- a/fsw/src/md_app.c
+++ b/fsw/src/md_app.c
@@ -622,10 +622,11 @@ void MD_ExecRequest(const CFE_SB_Buffer_t *BufPtr)
 
             case MD_RESET_CNTRS_CC:
 
-                CFE_EVS_SendEvent(MD_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Cmd Received");
-                MD_AppData.CmdCounter = 0;
-                MD_AppData.ErrCounter = 0;
-                break;
+              CFE_EVS_SendEvent(MD_RESET_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                "Reset Counters Cmd Received");
+              MD_AppData.CmdCounter = 0;
+              MD_AppData.ErrCounter = 0;
+              break;
 
             case MD_START_DWELL_CC:
 

--- a/unit-test/md_app_tests.c
+++ b/unit-test/md_app_tests.c
@@ -1439,7 +1439,8 @@ void MD_ExecRequest_Test_ResetCounters(void)
     UtAssert_True(MD_AppData.ErrCounter == 0, "MD_AppData.ErrCounter == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, MD_RESET_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType,
+                      CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #72
  - Updates Reset Counters command event type to `INFORMATION`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Reset Counters command event will be `INFORMATION`, aligning MD with the cFS standard.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt