### PR TITLE
Fix #71, Adds JSC 2.1 Static Analysis comments

### DIFF
--- a/fsw/src/md_dwell_tbl.c
+++ b/fsw/src/md_dwell_tbl.c
@@ -392,6 +392,7 @@ CFE_Status_t MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint
         strncpy(EntryPtr->DwellAddress.SymName, NewDwellAddress.SymName, OS_MAX_SYM_LEN - 1);
 
         /* Ensure string is null terminated. */
+        /* SAD: SymName’s last element is accessed on this line by reference to its max size, greatly reducing an off by one risk */
         EntryPtr->DwellAddress.SymName[OS_MAX_SYM_LEN - 1] = '\0';
 
         /* Notify Table Services that buffer was modified */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/MD/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #71, Adds a comment in the fsw to document where a static analysis warning has been flagged and why it's ok to leave the code in its current state.

**Testing performed**
Manual inspection

**Expected behavior changes**
None, only a comment is added.

**System(s) tested on**
N/A

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
