### PR TITLE
Fix #75, Use `size_t` for size variables/parameters + zero-out the gloabl data struct

### DIFF
--- a/fsw/src/md_app.c
+++ b/fsw/src/md_app.c
@@ -59,8 +59,6 @@ void MD_AppMain(void)
     CFE_SB_Buffer_t *BufPtr       = NULL;
     size_t           ActualLength = 0;
 
-    MD_AppData.RunStatus = CFE_ES_RunStatus_APP_RUN;
-
     /* Create the first Performance Log entry */
     CFE_ES_PerfLogEntry(MD_APPMAIN_PERF_ID);
 
@@ -176,8 +174,10 @@ CFE_Status_t MD_AppInit(void)
     */
     CFE_Status_t Status = CFE_SUCCESS;
 
-    MD_AppData.CmdCounter = 0;
-    MD_AppData.ErrCounter = 0;
+    /* Zero out the global data structure */
+    memset(&MD_AppData, 0, sizeof(MD_AppData));
+
+    MD_AppData.RunStatus = CFE_ES_RunStatus_APP_RUN;
 
     /* Initialize local control structures */
     MD_InitControlStructures();
@@ -656,7 +656,7 @@ void MD_HkStatus()
 {
     uint8                    TblIndex;
     uint16                   MemDwellEnableBits = 0;
-    MD_HkTlm_t *             HkPktPtr           = NULL;
+    MD_HkTlm_t              *HkPktPtr           = NULL;
     MD_DwellPacketControl_t *ThisDwellTablePtr  = NULL;
 
     /* Assign pointer used as shorthand to access Housekeeping Packet fields */

--- a/fsw/src/md_dwell_tbl.c
+++ b/fsw/src/md_dwell_tbl.c
@@ -295,7 +295,7 @@ void MD_CopyUpdatedTbl(MD_DwellTableLoad_t *MD_LoadTablePtr, uint8 TblIndex)
 {
     uint8                    EntryIndex;
     cpuaddr                  ResolvedAddr       = 0;
-    MD_TableLoadEntry_t *    ThisLoadEntry      = NULL;
+    MD_TableLoadEntry_t     *ThisLoadEntry      = NULL;
     MD_DwellPacketControl_t *LocalControlStruct = &MD_AppData.MD_DwellTables[TblIndex];
 
     /* Null check on MD_LoadTablePtr not necessary - table passed validation */
@@ -343,8 +343,8 @@ CFE_Status_t MD_UpdateTableEnabledField(uint16 TableIndex, uint16 FieldValue)
     if ((Status != CFE_SUCCESS) && (Status != CFE_TBL_INFO_UPDATED))
     {
         CFE_EVS_SendEvent(MD_UPDATE_TBL_EN_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "MD_UpdateTableEnabledField, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x",
-                          (int)TableIndex, (unsigned int)Status);
+                          "%s, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x", __func__, (int)TableIndex,
+                          (unsigned int)Status);
     }
     else
     {
@@ -375,8 +375,8 @@ CFE_Status_t MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint
     if ((Status != CFE_SUCCESS) && (Status != CFE_TBL_INFO_UPDATED))
     {
         CFE_EVS_SendEvent(MD_UPDATE_TBL_DWELL_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "MD_UpdateTableDwellEntry, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x",
-                          (int)TableIndex, (unsigned int)Status);
+                          "%s, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x", __func__, (int)TableIndex,
+                          (unsigned int)Status);
     }
     else
     {
@@ -392,7 +392,8 @@ CFE_Status_t MD_UpdateTableDwellEntry(uint16 TableIndex, uint16 EntryIndex, uint
         strncpy(EntryPtr->DwellAddress.SymName, NewDwellAddress.SymName, OS_MAX_SYM_LEN - 1);
 
         /* Ensure string is null terminated. */
-        /* SAD: SymName’s last element is accessed on this line by reference to its max size, greatly reducing an off by one risk */
+        /* SAD: SymName’s last element is accessed on this line by reference to its max size, greatly reducing an off by
+         * one risk */
         EntryPtr->DwellAddress.SymName[OS_MAX_SYM_LEN - 1] = '\0';
 
         /* Notify Table Services that buffer was modified */
@@ -421,7 +422,7 @@ CFE_Status_t MD_UpdateTableSignature(uint16 TableIndex, char NewSignature[MD_SIG
     if ((Status != CFE_SUCCESS) && (Status != CFE_TBL_INFO_UPDATED))
     {
         CFE_EVS_SendEvent(MD_UPDATE_TBL_SIG_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "MD_UpdateTableSignature, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x", (int)TableIndex,
+                          "%s, TableIndex %d: CFE_TBL_GetAddress Returned 0x%08x", __func__, (int)TableIndex,
                           (unsigned int)Status);
     }
     else

--- a/fsw/src/md_utils.c
+++ b/fsw/src/md_utils.c
@@ -101,7 +101,7 @@ bool MD_ValidEntryId(uint16 EntryId)
 
 /******************************************************************************/
 
-bool MD_ValidAddrRange(cpuaddr Addr, uint32 Size)
+bool MD_ValidAddrRange(cpuaddr Addr, size_t Size)
 {
     bool IsValid = false;
 
@@ -142,7 +142,7 @@ bool MD_ValidFieldLength(uint16 FieldLength)
 
 /******************************************************************************/
 
-bool MD_Verify32Aligned(cpuaddr Address, uint32 Size)
+bool MD_Verify32Aligned(cpuaddr Address, size_t Size)
 {
     bool IsAligned;
 
@@ -164,7 +164,7 @@ bool MD_Verify32Aligned(cpuaddr Address, uint32 Size)
 
 /******************************************************************************/
 
-bool MD_Verify16Aligned(cpuaddr Address, uint32 Size)
+bool MD_Verify16Aligned(cpuaddr Address, size_t Size)
 {
     bool IsAligned;
 

--- a/fsw/src/md_utils.h
+++ b/fsw/src/md_utils.h
@@ -96,7 +96,7 @@ bool MD_ValidEntryId(uint16 EntryId);
  * \retval true  Address is valid
  * \retval false Address is not valid
  */
-bool MD_ValidAddrRange(cpuaddr Addr, uint32 Size);
+bool MD_ValidAddrRange(cpuaddr Addr, size_t Size);
 
 /**
  * \brief Validate Table ID
@@ -156,7 +156,7 @@ bool MD_ValidFieldLength(uint16 FieldLength);
  *
  *  \sa #MD_Verify16Aligned
  */
-bool MD_Verify32Aligned(cpuaddr Address, uint32 Size);
+bool MD_Verify32Aligned(cpuaddr Address, size_t Size);
 
 /**
  * \brief Verify 16 bit alignment
@@ -178,7 +178,7 @@ bool MD_Verify32Aligned(cpuaddr Address, uint32 Size);
  *
  *  \sa #MD_Verify32Aligned
  */
-bool MD_Verify16Aligned(cpuaddr Address, uint32 Size);
+bool MD_Verify16Aligned(cpuaddr Address, size_t Size);
 
 /**
  * \brief Resolve symbolic address

--- a/unit-test/md_app_tests.c
+++ b/unit-test/md_app_tests.c
@@ -868,7 +868,7 @@ void MD_InitTableServices_Test_TblRecoveredNotValid(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_Register), 1, CFE_TBL_INFO_RECOVERED_TBL);
 
     /* Set to fail condition "GetAddressResult != CFE_TBL_INFO_UPDATED", to
-       prevent a core dump by assigning MD_LoadTablePtr, and to make MD_TableValidateionFunc() return non-success */
+       prevent a core dump by assigning MD_LoadTablePtr, and to make MD_TableValidationFunc() return non-success */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
 
     MD_AppData.MD_DwellTables[0].Enabled = MD_DWELL_STREAM_DISABLED;
@@ -927,7 +927,7 @@ void MD_InitTableServices_Test_DwellStreamEnabled(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_Register), 1, CFE_TBL_INFO_RECOVERED_TBL);
 
     /* Set to fail condition "GetAddressResult != CFE_TBL_INFO_UPDATED", to
-       prevent a core dump by assigning MD_LoadTablePtr, and to make MD_TableValidateionFunc() return non-success */
+       prevent a core dump by assigning MD_LoadTablePtr, and to make MD_TableValidationFunc() return non-success */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
 
     LoadTblPtr->Enabled = MD_DWELL_STREAM_ENABLED;
@@ -986,7 +986,7 @@ void MD_InitTableServices_Test_TblNotRecovered(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_Register), 1, CFE_TBL_INFO_RECOVERED_TBL);
 
     /* Set to fail condition "GetAddressResult != CFE_TBL_INFO_UPDATED", to
-       prevent a core dump by assigning MD_LoadTablePtr, and to make MD_TableValidateionFunc() return non-success */
+       prevent a core dump by assigning MD_LoadTablePtr, and to make MD_TableValidationFunc() return non-success */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
 
     LoadTblPtr->Enabled = MD_DWELL_STREAM_ENABLED;
@@ -1160,6 +1160,7 @@ void MD_ManageDwellTable_Test_UpdatePendingDwellStreamEnabled(void)
     uint8                TblIndex = 0;
     MD_DwellTableLoad_t  LoadTbl;
     MD_DwellTableLoad_t *LoadTblPtr = &LoadTbl;
+    uint8                call_count_MD_StartDwellStream;
 
     /* Set to satisfy condition "Status == CFE_TBL_INFO_UPDATE_PENDING" */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetStatus), 1, CFE_TBL_INFO_UPDATE_PENDING);
@@ -1183,7 +1184,7 @@ void MD_ManageDwellTable_Test_UpdatePendingDwellStreamEnabled(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 
-    uint8 call_count_MD_StartDwellStream = UT_GetStubCount(UT_KEY(MD_StartDwellStream));
+    call_count_MD_StartDwellStream = UT_GetStubCount(UT_KEY(MD_StartDwellStream));
     UtAssert_INT32_EQ(call_count_MD_StartDwellStream, 1);
 }
 
@@ -1193,6 +1194,7 @@ void MD_ManageDwellTable_Test_UpdatePendingDwellStreamDisabled(void)
     uint8                TblIndex = 0;
     MD_DwellTableLoad_t  LoadTbl;
     MD_DwellTableLoad_t *LoadTblPtr = &LoadTbl;
+    uint8                call_count_MD_StartDwellStream;
 
     /* Set to satisfy condition "Status == CFE_TBL_INFO_UPDATE_PENDING" */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetStatus), 1, CFE_TBL_INFO_UPDATE_PENDING);
@@ -1218,7 +1220,7 @@ void MD_ManageDwellTable_Test_UpdatePendingDwellStreamDisabled(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 
-    uint8 call_count_MD_StartDwellStream = UT_GetStubCount(UT_KEY(MD_StartDwellStream));
+    call_count_MD_StartDwellStream = UT_GetStubCount(UT_KEY(MD_StartDwellStream));
     UtAssert_INT32_EQ(call_count_MD_StartDwellStream, 0);
 }
 

--- a/unit-test/md_dwell_tbl_tests.c
+++ b/unit-test/md_dwell_tbl_tests.c
@@ -945,7 +945,7 @@ void MD_UpdateTableEnabledField_Test_Error(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "MD_UpdateTableEnabledField, TableIndex %%d: CFE_TBL_GetAddress Returned 0x%%08x");
+             "%%s, TableIndex %%d: CFE_TBL_GetAddress Returned 0x%%08x");
 
     /* Set to make CFE_TBL_GetAddress != CFE_SUCCESS */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, -1);
@@ -1056,7 +1056,7 @@ void MD_UpdateTableDwellEntry_Test_Error(void)
     char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "MD_UpdateTableDwellEntry, TableIndex %%d: CFE_TBL_GetAddress Returned 0x%%08x");
+             "%%s, TableIndex %%d: CFE_TBL_GetAddress Returned 0x%%08x");
 
     NewDwellAddress.Offset = 1;
 
@@ -1139,7 +1139,7 @@ void MD_UpdateTableSignature_Test_Error(void)
     char   ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "MD_UpdateTableSignature, TableIndex %%d: CFE_TBL_GetAddress Returned 0x%%08x");
+             "%%s, TableIndex %%d: CFE_TBL_GetAddress Returned 0x%%08x");
 
     /* Set to make CFE_TBL_GetAddress != CFE_SUCCESS */
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, -1);

--- a/unit-test/md_utils_tests.c
+++ b/unit-test/md_utils_tests.c
@@ -203,7 +203,7 @@ void MD_ValidAddrRange_Test_Valid(void)
 {
     bool    Result;
     cpuaddr Addr = 1;
-    uint32  Size = 1;
+    size_t  Size = 1;
 
     /* Execute the function being tested */
     Result = MD_ValidAddrRange(Addr, Size);
@@ -221,7 +221,7 @@ void MD_ValidAddrRange_Test_Invalid(void)
 {
     bool    Result;
     cpuaddr Addr = 1;
-    uint32  Size = 1;
+    size_t  Size = 1;
 
     /* Set to reach "IsValid = false" */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -378,7 +378,7 @@ void MD_Verify32Aligned_Test(void)
 {
     bool    Result;
     cpuaddr Addr;
-    uint32  Size;
+    size_t  Size;
 
     Addr = 0; /* address is aligned */
     Size = 4; /* size is aligned */
@@ -412,7 +412,7 @@ void MD_Verify16Aligned_Test(void)
 {
     bool    Result;
     cpuaddr Addr;
-    uint32  Size;
+    size_t  Size;
 
     Addr = 0; /* address is aligned */
     Size = 4; /* size is aligned */

--- a/unit-test/stubs/md_utils_stubs.c
+++ b/unit-test/stubs/md_utils_stubs.c
@@ -48,7 +48,7 @@ bool MD_ValidEntryId(uint16 EntryId)
     return UT_DEFAULT_IMPL(MD_ValidEntryId) != 0;
 }
 
-bool MD_ValidAddrRange(cpuaddr Addr, uint32 Size)
+bool MD_ValidAddrRange(cpuaddr Addr, size_t Size)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_ValidAddrRange), Addr);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_ValidAddrRange), Size);
@@ -67,14 +67,14 @@ bool MD_ValidFieldLength(uint16 FieldLength)
     return UT_DEFAULT_IMPL(MD_ValidFieldLength) != 0;
 }
 
-bool MD_Verify32Aligned(cpuaddr Address, uint32 Size)
+bool MD_Verify32Aligned(cpuaddr Address, size_t Size)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_Verify32Aligned), Address);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_Verify32Aligned), Size);
     return UT_DEFAULT_IMPL(MD_Verify32Aligned) != 0;
 }
 
-bool MD_Verify16Aligned(cpuaddr Address, uint32 Size)
+bool MD_Verify16Aligned(cpuaddr Address, size_t Size)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_Verify16Aligned), Address);
     UT_Stub_RegisterContextGenericArg(UT_KEY(MD_Verify16Aligned), Size);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #75
  - Converts suitable variables + function parameters that represent size to the `size_t` type
  - Zero's out the global data struct at the beginning of initialization
  - A couple of minor fixes are added here including typos and replacing some function name text to use `__func__` (to avoid potential future technical debt)

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**System(s) tested on**
Debian GNU/Linux 12 (bookworm)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt