### PR TITLE
Fix #96, terminate symbol names without changing inputs

### DIFF
--- a/fsw/src/md_cmds.c
+++ b/fsw/src/md_cmds.c
@@ -258,9 +258,6 @@ CFE_Status_t MD_JamDwellCmd(const MD_JamDwellCmd_t *Msg)
 
     Status = CFE_SUCCESS;
 
-    /* In case Dwell Address sym name isn't null terminated, do it now. */
-    // Msg->Payload.DwellAddress.SymName[CFE_MISSION_MAX_PATH_LEN - 1] = '\0';
-
     /*
     **  Check that TableId and EntryId command arguments,
     **  which are used as array indexes, are valid.
@@ -351,7 +348,8 @@ CFE_Status_t MD_JamDwellCmd(const MD_JamDwellCmd_t *Msg)
                 /* If DwellAddress argument couldn't be resolved, issue error event */
                 CFE_EVS_SendEvent(MD_CANT_RESOLVE_JAM_ADDR_ERR_EID,
                                   CFE_EVS_EventType_ERROR,
-                                  "Jam Cmd rejected because symbolic address '%s' couldn't be resolved",
+                                  "Jam Cmd rejected because symbolic address '%.*s' couldn't be resolved",
+                                  (int)sizeof(Msg->Payload.DwellAddress.SymName),
                                   Msg->Payload.DwellAddress.SymName);
                 AllInputsValid = false;
             }

--- a/fsw/src/md_dwell_tbl.c
+++ b/fsw/src/md_dwell_tbl.c
@@ -120,7 +120,8 @@ int32 MD_TableValidationFunc(void *TblPtr)
             CFE_EVS_SendEvent(
                 MD_RESOLVE_ERR_EID,
                 CFE_EVS_EventType_ERROR,
-                "Dwell Table rejected because address (sym='%s'/offset=0x%08X) in entry #%d couldn't be resolved",
+                "Dwell Table rejected because address (sym='%.*s'/offset=0x%08X) in entry #%d couldn't be resolved",
+                (int)sizeof(LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.SymName),
                 LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.SymName,
                 (unsigned int)LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.Offset,
                 TblErrorEntryIndex + 1);
@@ -130,7 +131,8 @@ int32 MD_TableValidationFunc(void *TblPtr)
             CFE_EVS_SendEvent(
                 MD_RANGE_ERR_EID,
                 CFE_EVS_EventType_ERROR,
-                "Dwell Table rejected because address (sym='%s'/offset=0x%08X) in entry #%d was out of range",
+                "Dwell Table rejected because address (sym='%.*s'/offset=0x%08X) in entry #%d was out of range",
+                (int)sizeof(LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.SymName),
                 LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.SymName,
                 (unsigned int)LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.Offset,
                 TblErrorEntryIndex + 1);
@@ -145,14 +147,16 @@ int32 MD_TableValidationFunc(void *TblPtr)
         }
         else /* Status == MD_NOT_ALIGNED_ERROR is only remaining option */
         {
-            CFE_EVS_SendEvent(MD_TBL_ALIGN_ERR_EID,
-                              CFE_EVS_EventType_ERROR,
-                              "Dwell Table rejected because address (sym='%s'/offset=0x%08X) in entry #%d not properly "
-                              "aligned for %d-byte dwell",
-                              LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.SymName,
-                              (unsigned int)LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.Offset,
-                              TblErrorEntryIndex + 1,
-                              LocalTblPtr->Entry[TblErrorEntryIndex].Length);
+            CFE_EVS_SendEvent(
+                MD_TBL_ALIGN_ERR_EID,
+                CFE_EVS_EventType_ERROR,
+                "Dwell Table rejected because address (sym='%.*s'/offset=0x%08X) in entry #%d not properly "
+                "aligned for %d-byte dwell",
+                (int)sizeof(LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.SymName),
+                LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.SymName,
+                (unsigned int)LocalTblPtr->Entry[TblErrorEntryIndex].DwellAddress.Offset,
+                TblErrorEntryIndex + 1,
+                LocalTblPtr->Entry[TblErrorEntryIndex].Length);
         }
 
     } /* end else MD_ReadDwellTable */

--- a/fsw/src/md_utils.c
+++ b/fsw/src/md_utils.c
@@ -189,18 +189,13 @@ bool MD_ResolveSymAddr(const MD_SymAddr_t *SymAddr, cpuaddr *ResolvedAddr)
 {
     bool  Valid;
     int32 OS_Status;
-
-    /*
-    ** NUL terminate the very end of the symbol name string array as a
-    ** safety measure
-    */
-    // SymAddr->SymName[CFE_MISSION_MAX_PATH_LEN - 1] = '\0';
+    char  SymbolName[sizeof(SymAddr->SymName)];
 
     /*
     ** If the symbol name string is a nul string
     ** we use the offset as the absolute address
     */
-    if (strlen(SymAddr->SymName) == 0)
+    if (SymAddr->SymName[0] == '\0')
     {
         *ResolvedAddr = SymAddr->Offset;
         Valid         = true;
@@ -211,7 +206,10 @@ bool MD_ResolveSymAddr(const MD_SymAddr_t *SymAddr, cpuaddr *ResolvedAddr)
         ** If symbol name is not an empty string look it up
         ** using the OSAL API and add the offset if it succeeds
         */
-        OS_Status = OS_SymbolLookup(ResolvedAddr, SymAddr->SymName);
+        /* Terminate a bounded local copy without modifying the command or table. */
+        memcpy(SymbolName, SymAddr->SymName, sizeof(SymbolName));
+        SymbolName[sizeof(SymbolName) - 1] = '\0';
+        OS_Status                          = OS_SymbolLookup(ResolvedAddr, SymbolName);
         if (OS_Status == OS_SUCCESS)
         {
             *ResolvedAddr += SymAddr->Offset;

--- a/fsw/src/md_utils.h
+++ b/fsw/src/md_utils.h
@@ -199,6 +199,9 @@ bool MD_Verify16Aligned(cpuaddr Address, uint32 Size);
  *  \retval true  Symbolic address was resolved
  *  \retval false Symbolic address was not resolved
  *
+ *  Symbol names are terminated in a local copy limited to the field size minus
+ *  one. The caller's command or table buffer is not modified.
+ *
  *  \sa #OS_SymbolLookup
  */
 bool MD_ResolveSymAddr(const MD_SymAddr_t *SymAddr, cpuaddr *ResolvedAddr);

--- a/unit-test/md_cmds_tests.c
+++ b/unit-test/md_cmds_tests.c
@@ -702,7 +702,7 @@ void MD_ProcessJamCmd_Test_CantResolveJamAddr(void)
 
     snprintf(ExpectedEventString,
              CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Jam Cmd rejected because symbolic address '%%s' couldn't be resolved");
+             "Jam Cmd rejected because symbolic address '%%.*s' couldn't be resolved");
 
     TestMsgId = CFE_SB_ValueToMsgId(MD_CMD_MID);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
@@ -1420,8 +1420,53 @@ void MD_ProcessSignatureCmd_Test_NoUpdateTableSignature(void)
 }
 #endif
 
+static void MD_Test_CaptureJamEvent(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context, va_list Args)
+{
+    const char *Format = UT_Hook_GetArgValueByName(Context, "Spec", const char *);
+    vsnprintf(UserObj, 512, Format, Args);
+}
+
+void MD_ProcessJamCmd_Test_UnterminatedSymbolEvent(void)
+{
+    struct
+    {
+        MD_JamDwellCmd_t Msg;
+        char             Guard[8];
+    } Input;
+    char Event[512];
+    char Expected[512];
+
+    memset(&Input, 'X', sizeof(Input));
+    Input.Guard[sizeof(Input.Guard) - 1] = '\0';
+    Input.Msg.Payload.TableId            = 1;
+    Input.Msg.Payload.EntryId            = 1;
+    Input.Msg.Payload.FieldLength        = 1;
+    UT_SetDefaultReturnValue(UT_KEY(MD_ValidTableId), true);
+    UT_SetDefaultReturnValue(UT_KEY(MD_ValidEntryId), true);
+    UT_SetDefaultReturnValue(UT_KEY(MD_ResolveSymAddr), false);
+    UT_SetVaHandlerFunction(UT_KEY(CFE_EVS_SendEvent), MD_Test_CaptureJamEvent, Event);
+
+    MD_JamDwellCmd(&Input.Msg);
+
+    snprintf(Expected,
+             sizeof(Expected),
+             "Jam Cmd rejected because symbolic address '%.*s' couldn't be resolved",
+             (int)sizeof(Input.Msg.Payload.DwellAddress.SymName),
+             Input.Msg.Payload.DwellAddress.SymName);
+    UtAssert_True(strcmp(Event, Expected) == 0, "Jam diagnostic stops at the symbol field boundary");
+    UtAssert_UINT32_EQ(MD_AppData.CommandErrorCounter, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_True(memchr(Input.Msg.Payload.DwellAddress.SymName, '\0', sizeof(Input.Msg.Payload.DwellAddress.SymName))
+                      == NULL,
+                  "Jam input remains unchanged");
+}
+
 void UtTest_Setup(void)
 {
+    UtTest_Add(MD_ProcessJamCmd_Test_UnterminatedSymbolEvent,
+               MD_Test_Setup,
+               MD_Test_TearDown,
+               "Bound unterminated jam event");
     UtTest_Add(MD_NoopCmd_Test, MD_Test_Setup, MD_Test_TearDown, "MD_NoopCmd_Test");
     UtTest_Add(MD_ResetCountersCmd_Test, MD_Test_Setup, MD_Test_TearDown, "MD_ResetCountersCmd_Test");
 

--- a/unit-test/md_dwell_tbl_tests.c
+++ b/unit-test/md_dwell_tbl_tests.c
@@ -126,7 +126,7 @@ void MD_TableValidationFunc_Test_ResolveError(void)
 
     snprintf(ExpectedEventString,
              CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dwell Table rejected because address (sym='%%s'/offset=0x%%08X) in entry #%%d couldn't be resolved");
+             "Dwell Table rejected because address (sym='%%.*s'/offset=0x%%08X) in entry #%%d couldn't be resolved");
 
     Table.Enabled = MD_Dwell_States_ENABLED;
 
@@ -173,7 +173,7 @@ void MD_TableValidationFunc_Test_InvalidAddress(void)
 
     snprintf(ExpectedEventString,
              CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dwell Table rejected because address (sym='%%s'/offset=0x%%08X) in entry #%%d was out of range");
+             "Dwell Table rejected because address (sym='%%.*s'/offset=0x%%08X) in entry #%%d was out of range");
 
     Table.Enabled = MD_Dwell_States_ENABLED;
 
@@ -318,7 +318,7 @@ void MD_TableValidationFunc_Test_NotAligned(void)
 
     snprintf(ExpectedEventString,
              CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Dwell Table rejected because address (sym='%%s'/offset=0x%%08X) in entry #%%d not properly aligned for "
+             "Dwell Table rejected because address (sym='%%.*s'/offset=0x%%08X) in entry #%%d not properly aligned for "
              "%%d-byte dwell");
 
     Table.Enabled = MD_Dwell_States_ENABLED;
@@ -1204,8 +1204,63 @@ void MD_UpdateTableSignature_Test_Error(void)
 
 #endif
 
+static void
+MD_Test_CaptureTableEvent(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context, va_list Args)
+{
+    uint16      EventId = UT_Hook_GetArgValueByName(Context, "EventID", uint16);
+    const char *Format  = UT_Hook_GetArgValueByName(Context, "Spec", const char *);
+    if (EventId == MD_RESOLVE_ERR_EID || EventId == MD_RANGE_ERR_EID || EventId == MD_TBL_ALIGN_ERR_EID)
+    {
+        vsnprintf(UserObj, 512, Format, Args);
+    }
+}
+
+void MD_TableValidationFunc_Test_UnterminatedSymbolEvents(void)
+{
+    MD_DwellTableLoad_t Table;
+    char                Event[512];
+    char                ExpectedSymbol[sizeof(Table.Entry[0].DwellAddress.SymName) + 1];
+    const int32         Errors[] = { MD_RESOLVE_ERROR, MD_INVALID_ADDR_ERROR, MD_NOT_ALIGNED_ERROR };
+    size_t              Index;
+
+    memset(ExpectedSymbol, 'X', sizeof(ExpectedSymbol) - 1);
+    ExpectedSymbol[sizeof(ExpectedSymbol) - 1] = '\0';
+    for (Index = 0; Index < sizeof(Errors) / sizeof(Errors[0]); ++Index)
+    {
+        MD_Test_Setup();
+        memset(&Table, 0, sizeof(Table));
+        Table.Enabled = MD_Dwell_States_ENABLED;
+        memset(Table.Entry[0].DwellAddress.SymName, 'X', sizeof(Table.Entry[0].DwellAddress.SymName));
+        Table.Entry[0].Length = Errors[Index] == MD_NOT_ALIGNED_ERROR ? 2 : 1;
+        UT_SetDefaultReturnValue(UT_KEY(MD_ResolveSymAddr), Errors[Index] != MD_RESOLVE_ERROR);
+        UT_SetDefaultReturnValue(UT_KEY(MD_ValidAddrRange), Errors[Index] != MD_INVALID_ADDR_ERROR);
+        UT_SetDefaultReturnValue(UT_KEY(MD_ValidFieldLength), true);
+        UT_SetDefaultReturnValue(UT_KEY(MD_Verify16Aligned), false);
+        UT_SetVaHandlerFunction(UT_KEY(CFE_EVS_SendEvent), MD_Test_CaptureTableEvent, Event);
+        Event[0] = '\0';
+
+        UtAssert_INT32_EQ(MD_TableValidationFunc(&Table), Errors[Index]);
+        const char *Symbol = strstr(Event, "sym='");
+        UtAssert_True(Symbol != NULL, "Error event contains the symbolic address");
+        if (Symbol != NULL)
+        {
+            Symbol += 5;
+            UtAssert_True(memcmp(Symbol, ExpectedSymbol, sizeof(ExpectedSymbol) - 1) == 0,
+                          "Event retains all bytes within the symbol field");
+            UtAssert_True(Symbol[sizeof(ExpectedSymbol) - 1] == '\'', "Table diagnostic stops at the field boundary");
+        }
+        UtAssert_True(memchr(Table.Entry[0].DwellAddress.SymName, '\0', sizeof(Table.Entry[0].DwellAddress.SymName))
+                          == NULL,
+                      "Table input remains unchanged");
+    }
+}
+
 void UtTest_Setup(void)
 {
+    UtTest_Add(MD_TableValidationFunc_Test_UnterminatedSymbolEvents,
+               MD_Test_Setup,
+               MD_Test_TearDown,
+               "Bound unterminated table events");
     UtTest_Add(MD_TableValidationFunc_Test_InvalidEnableFlag,
                MD_Test_Setup,
                MD_Test_TearDown,

--- a/unit-test/md_utils_tests.c
+++ b/unit-test/md_utils_tests.c
@@ -498,6 +498,64 @@ void MD_ResolveSymAddr_Test(void)
     UtAssert_True(Result == false, "Result == false");
 }
 
+static void MD_Test_SymbolLookup(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    const MD_SymAddr_t *Input   = UserObj;
+    const char         *Name    = UT_Hook_GetArgValueByName(Context, "symbol_name", const char *);
+    cpuaddr            *Address = UT_Hook_GetArgValueByName(Context, "symbol_address", cpuaddr *);
+    char                Expected[sizeof(Input->SymName)];
+
+    memcpy(Expected, Input->SymName, sizeof(Expected));
+    Expected[sizeof(Expected) - 1] = '\0';
+    if (UtAssert_True(memchr(Name, '\0', sizeof(Expected)) != NULL, "Lookup name is bounded and terminated"))
+    {
+        UtAssert_True(strcmp(Name, Expected) == 0, "Lookup preserves the bounded symbol name");
+    }
+    *Address = 4096;
+}
+
+void MD_ResolveSymAddr_Test_Unterminated(void)
+{
+    MD_SymAddr_t Input;
+    MD_SymAddr_t Original;
+    cpuaddr      Address = 0;
+
+    memset(&Input, 'X', sizeof(Input));
+    Input.Offset = 7;
+    memcpy(&Original, &Input, sizeof(Input));
+    UT_SetHandlerFunction(UT_KEY(OS_SymbolLookup), MD_Test_SymbolLookup, &Input);
+    UtAssert_True(MD_ResolveSymAddr(&Input, &Address), "Resolve a full-width symbol through a local copy");
+    UtAssert_True(Address == 4103, "Add the offset after successful lookup");
+    UtAssert_True(memcmp(&Input, &Original, sizeof(Input)) == 0, "Input remains unchanged");
+
+    UT_SetDefaultReturnValue(UT_KEY(OS_SymbolLookup), OS_ERROR);
+    UtAssert_True(!MD_ResolveSymAddr(&Input, &Address), "Lookup failure is preserved");
+    UtAssert_True(Address == 4096, "Do not add the offset after lookup failure");
+    UtAssert_True(memcmp(&Input, &Original, sizeof(Input)) == 0, "Failed lookup also preserves input");
+    UtAssert_STUB_COUNT(OS_SymbolLookup, 2);
+}
+
+void MD_ResolveSymAddr_Test_TerminationBoundaries(void)
+{
+    MD_SymAddr_t Input;
+    MD_SymAddr_t Original;
+    cpuaddr      Address = 0;
+    size_t       Length;
+
+    for (Length = 0; Length < sizeof(Input.SymName); ++Length)
+    {
+        memset(&Input, 'X', sizeof(Input));
+        Input.Offset          = 7;
+        Input.SymName[Length] = '\0';
+        memcpy(&Original, &Input, sizeof(Input));
+        UT_SetHandlerFunction(UT_KEY(OS_SymbolLookup), MD_Test_SymbolLookup, &Input);
+        UtAssert_True(MD_ResolveSymAddr(&Input, &Address), "Resolve each termination position");
+        UtAssert_True(Address == (Length == 0 ? 7 : 4103), "Preserve absolute and symbolic addresses");
+        UtAssert_True(memcmp(&Input, &Original, sizeof(Input)) == 0, "Preserve input at each boundary");
+    }
+    UtAssert_STUB_COUNT(OS_SymbolLookup, sizeof(Input.SymName) - 1);
+}
+
 void UtTest_Setup(void)
 {
     UtTest_Add(MD_TableIsInMask_Test_ShiftOddResult,
@@ -550,6 +608,15 @@ void UtTest_Setup(void)
 
     UtTest_Add(MD_Verify32Aligned_Test, MD_Test_Setup, MD_Test_TearDown, "MD_Verify32Aligned_Test");
     UtTest_Add(MD_Verify16Aligned_Test, MD_Test_Setup, MD_Test_TearDown, "MD_Verify16Aligned_Test");
+
+    UtTest_Add(MD_ResolveSymAddr_Test_Unterminated,
+               MD_Test_Setup,
+               MD_Test_TearDown,
+               "Unterminated symbol is copied safely");
+    UtTest_Add(MD_ResolveSymAddr_Test_TerminationBoundaries,
+               MD_Test_Setup,
+               MD_Test_TearDown,
+               "All symbol termination boundaries");
 
     UtTest_Add(MD_ResolveSymAddr_Test, MD_Test_Setup, MD_Test_TearDown, "MD_ResolveSymAddr_Test");
 }


### PR DESCRIPTION
Fixes #96.

Restore symbol termination in a bounded local copy before `OS_SymbolLookup`, without modifying const command or table inputs. Check an empty name using its first byte, bound symbol formatting in jam/table error events, and remove the commented-out writes to caller buffers.

### Validation

Debian 12 arm64, GCC 12.2, native cFE/OSAL with EDS disabled:
- All six MD coverage targets passed: 149 test cases and 1,121 assertions. The suite passed 20 repetitions.
- All six test executables also passed with MD source and tests compiled under AddressSanitizer and UndefinedBehaviorSanitizer.
- Four new cases cover full-width nonterminated names, every termination position, lookup failures, unchanged inputs, and jam/table diagnostic formatting. The full-width lookup regression failed on unchanged upstream code.
- The flight application built. Changed lines formatted with clang-format 19 and the current cFS configuration; `git diff --check` passed.

Valid terminated names and absolute-address handling retain their behavior. A full-width name is terminated at the last field byte in the local lookup copy, matching the intent of the former commented-out assignment. No public signatures change.

Full mission/COSMOS, EDS-enabled, and hardware testing were not performed.

Contributor: Sylvester Kaczmarek, Personal. No third-party code added. Contributor License Agreement submission status is unverified.
